### PR TITLE
Existance Tests Updated for Test Analyzer

### DIFF
--- a/upgrade_tests/helpers/existence.py
+++ b/upgrade_tests/helpers/existence.py
@@ -239,3 +239,10 @@ def compare_postupgrade(component, attribute):
             postdata, component, search_key=test_case, attribute=attribute)
         entity_values.append((preupgrade_entiry, postupgrade_entity))
     return entity_values
+
+
+def pytest_ids(data):
+    """
+    """
+    ids = ["pre and post" for i in range(len(data))]
+    return ids

--- a/upgrade_tests/test_existance_relations/test_activationkeys.py
+++ b/upgrade_tests/test_existance_relations/test_activationkeys.py
@@ -16,13 +16,19 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
-from upgrade_tests.helpers.existence import compare_postupgrade
+from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 
-@pytest.mark.parametrize(
-    "pre,post",
-    compare_postupgrade('activation-key', 'content view')
-)
+# Required Data
+component = 'activation-key'
+aks_cv = compare_postupgrade(component, 'content view')
+aks_lc = compare_postupgrade(component, 'lifecycle environment')
+aks_name = compare_postupgrade(component, 'name')
+aks_hl = compare_postupgrade(component, 'host limit')
+
+
+# Tests
+@pytest.mark.parametrize("pre,post", aks_cv, pytest_ids(aks_cv))
 def test_positive_aks_by_content_view(pre, post):
     """Test CV association of all AKs post upgrade
 
@@ -33,10 +39,7 @@ def test_positive_aks_by_content_view(pre, post):
     assert pre == post
 
 
-@pytest.mark.parametrize(
-    "pre,post",
-    compare_postupgrade('activation-key', 'lifecycle environment')
-)
+@pytest.mark.parametrize("pre,post", aks_lc, pytest_ids(aks_lc))
 def test_positive_aks_by_lc(pre, post):
     """Test LC association of all AKs post upgrade
 
@@ -47,10 +50,7 @@ def test_positive_aks_by_lc(pre, post):
     assert pre == post
 
 
-@pytest.mark.parametrize(
-    "pre,post",
-    compare_postupgrade('activation-key', 'name')
-)
+@pytest.mark.parametrize("pre,post", aks_name, pytest_ids(aks_name))
 def test_positive_aks_by_name(pre, post):
     """Test AKs are existing by their name post upgrade
 
@@ -61,10 +61,7 @@ def test_positive_aks_by_name(pre, post):
     assert pre == post
 
 
-@pytest.mark.parametrize(
-    "pre,post",
-    compare_postupgrade('activation-key', 'host limit')
-)
+@pytest.mark.parametrize("pre,post", aks_hl, pytest_ids(aks_hl))
 def test_positive_aks_by_host_limit(pre, post):
     """Test host limit associations of all AKs post upgrade
 

--- a/upgrade_tests/test_existance_relations/test_architectures.py
+++ b/upgrade_tests/test_existance_relations/test_architectures.py
@@ -16,13 +16,15 @@ post upgrade
 :Upstream: No
 """
 import pytest
-from upgrade_tests.helpers.existence import compare_postupgrade
+from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
+
+# Required Data
+component = 'architecture'
+arc_name = compare_postupgrade(component, 'name')
 
 
-@pytest.mark.parametrize(
-    "pre,post",
-    compare_postupgrade('architecture', 'name')
-)
+# Tests
+@pytest.mark.parametrize("pre,post", arc_name, ids=pytest_ids(arc_name))
 def test_positive_architectures_by_name(pre, post):
     """Test all architectures are existing after upgrade by names
 

--- a/upgrade_tests/test_existance_relations/test_scparams.py
+++ b/upgrade_tests/test_existance_relations/test_scparams.py
@@ -16,13 +16,19 @@
 :Upstream: No
 """
 import pytest
-from upgrade_tests.helpers.existence import compare_postupgrade
+from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 
-@pytest.mark.parametrize(
-    "pre,post",
-    compare_postupgrade('sc-param', 'parameter')
-)
+# Required Data
+component = 'sc-param'
+scp_names = compare_postupgrade(component, 'parameter')
+scp_dval = compare_postupgrade(component, 'default value')
+scp_ovrde = compare_postupgrade(component, 'override')
+scp_pclass = compare_postupgrade(component, 'puppet class')
+
+
+# Tests
+@pytest.mark.parametrize("pre,post", scp_names, ids=pytest_ids(scp_names))
 def test_positive_smart_params_by_name(pre, post):
     """Test all smart parameters are existing after upgrade by names
 
@@ -34,10 +40,7 @@ def test_positive_smart_params_by_name(pre, post):
     assert pre == post
 
 
-@pytest.mark.parametrize(
-    "pre,post",
-    compare_postupgrade('sc-param', 'default value')
-)
+@pytest.mark.parametrize("pre,post", scp_dval, ids=pytest_ids(scp_dval))
 def test_positive_smart_params_by_default_value(pre, post):
     """Test all smart parameters default values are retained after upgrade
 
@@ -49,10 +52,7 @@ def test_positive_smart_params_by_default_value(pre, post):
     assert pre == post
 
 
-@pytest.mark.parametrize(
-    "pre,post",
-    compare_postupgrade('sc-param', 'override')
-)
+@pytest.mark.parametrize("pre,post", scp_ovrde, ids=pytest_ids(scp_ovrde))
 def test_positive_smart_params_by_override(pre, post):
     """Test all smart parameters override check is retained after upgrade
 
@@ -64,10 +64,7 @@ def test_positive_smart_params_by_override(pre, post):
     assert pre == post
 
 
-@pytest.mark.parametrize(
-    "pre,post",
-    compare_postupgrade('sc-param', 'puppet class')
-)
+@pytest.mark.parametrize("pre,post", scp_pclass, ids=pytest_ids(scp_pclass))
 def test_positive_smart_params_by_puppet_class(pre, post):
     """Test all smart parameters associations with its puppet class is retained
     after upgrade


### PR DESCRIPTION
This solves the issue with Jeknins Test Results Analyzer. This will always have the same test name and wont append the data to the testname.

What is the issue ?
test_positive_ak_by_name['rhel6_ak'-'rhel6_ak']

What is fix?
test_positive_ak_by_name['pre and post']

So the data of test wont be appended now, and the test results analyzing will show the trends for last all runs.