### PR TITLE
Added use-case testing support to upgrade testing.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+fauxfactory==2.0.9
+
 # Get automation-tools from master
 git+https://github.com/SatelliteQE/automation-tools#egg=automation-tools

--- a/upgrade/helpers/docker.py
+++ b/upgrade/helpers/docker.py
@@ -8,12 +8,14 @@ from fabric.api import run
 logger = logger()
 
 
-def generate_satellite_docker_clients_on_rhevm(client_os, clients_count):
+def generate_satellite_docker_clients_on_rhevm(
+        client_os, clients_count, ak=None):
     """Generates satellite clients on docker as containers
 
     :param string client_os: Client OS of which client to be generated
         e.g: rhel6, rhel7
     :param string clients_count: No of clients to generate
+    :param string ak: Activation key name, to register clients
 
     Environment Variables:
 
@@ -28,7 +30,10 @@ def generate_satellite_docker_clients_on_rhevm(client_os, clients_count):
             'Clients count to generate on Docker should be atleast 1 !')
         sys.exit(1)
     satellite_hostname = os.environ.get('RHEV_SAT_HOST')
-    ak = os.environ.get('RHEV_CLIENT_AK_{}'.format(client_os.upper()))
+    if ak:
+        ak = ak
+    else:
+        ak = os.environ.get('RHEV_CLIENT_AK_{}'.format(client_os.upper()))
     result = {}
     for count in range(int(clients_count)):
         if bz_bug_is_open('1405085'):

--- a/upgrade_tests/__init__.py
+++ b/upgrade_tests/__init__.py
@@ -1,0 +1,5 @@
+import pytest
+
+pre_upgrade = pytest.mark.pre_upgrade
+# Association tests
+post_upgrade = pytest.mark.post_upgrade

--- a/upgrade_tests/helpers/scenarios.py
+++ b/upgrade_tests/helpers/scenarios.py
@@ -1,0 +1,123 @@
+"""All the helper functions, needed for scenarios test case automation to be
+added here"""
+import os
+import json
+import time
+
+from automation_tools import manage_daemon
+from upgrade.helpers.docker import (
+    remove_all_docker_containers,
+    generate_satellite_docker_clients_on_rhevm
+)
+from upgrade.helpers.rhevm import (
+    create_rhevm_instance,
+    get_rhevm_client,
+    wait_till_rhevm_instance_status
+)
+from upgrade.helpers.logger import logger
+from fabric.api import execute
+
+rpm1 = 'https://inecas.fedorapeople.org/fakerepos/zoo3/bear-4.1-1.noarch.rpm'
+rpm2 = 'https://inecas.fedorapeople.org/fakerepos/zoo3/camel-0.1-1.noarch.rpm'
+data = {}
+
+logger = logger()
+
+
+def create_dict(entities_dict):
+    """Stores a global dictionary of entities created in satellite by the
+    scenarios tested, so that these entities can be retrieved post upgrade
+    to assert the test cases.
+
+    :param string entities_dict: A dictionary of entities created in
+        satellite
+    """
+    data.update(entities_dict)
+    with open('scenario_entities', 'wb') as pref:
+        json.dump(data, pref)
+
+
+def get_entity_data(scenario_name):
+    """Fetches the dictionary of entities from the disk depending on the
+    Scenario name (class name in which test is defined)
+
+    :param string scenario_name : The name of the class for which the data is
+        to fetched
+    :returns dict entity_data : Returns a dictionary of entities
+    """
+    with open('scenario_entities') as pref:
+        entity_data = json.load(pref)
+        entity_data = entity_data[scenario_name]
+    return entity_data
+
+
+def dockerize(ak_name, distro):
+    """Creates Docker Container's of specified distro and subscribes them to
+    given AK
+
+    :param string ak_name : Activation Key name, to be used to subscribe
+    the docker container's
+    :param string distro : The OS of the VM to be created.
+        Supported are 'rhel7' and 'rhel6'
+    :returns dict clients : A dictonary which contain's container name
+    and id.
+
+    Environment Variable:
+
+    DOCKER_VM
+        The Docker VM IP/Hostname on rhevm to create clients
+    """
+    docker_vm = os.environ.get('DOCKER_VM')
+    # Check if the VM containing docker images is up, else turn on
+    rhevm_client = get_rhevm_client()
+    instance_name = 'sat6-docker-upgrade'
+    template_name = 'sat6-docker-upgrade-template'
+    vm = rhevm_client.vms.get(name=instance_name)
+    if not vm:
+        logger.info('Docker VM for generating Content Host is not created.'
+                    'Creating it, please wait..')
+        create_rhevm_instance(instance_name, template_name)
+        execute(manage_daemon, 'restart', 'docker', host=docker_vm)
+    elif vm.get_status().get_state() == 'down':
+        logger.info('Docker VM for generating Content Host is not up. '
+                    'Turning on, please wait ....')
+        rhevm_client.vms.get(name=instance_name).start()
+        wait_till_rhevm_instance_status(instance_name, 'up', 5)
+        execute(manage_daemon, 'restart', 'docker', host=docker_vm)
+    rhevm_client.disconnect()
+    time.sleep(5)
+    logger.info('Generating client on RHEL7 on Docker. '
+                'Please wait .....')
+    # First delete if any containers running
+    execute(
+        remove_all_docker_containers, only_running=False, host=docker_vm)
+    # Generate Clients on RHEL 7
+    time.sleep(30)
+    clients = execute(
+        generate_satellite_docker_clients_on_rhevm,
+        distro,
+        1,
+        ak_name,
+        host=docker_vm,
+    )[docker_vm]
+    return clients
+
+
+def get_satellite_host():
+    """Get the satellite hostname depending on which jenkins variables are set
+
+    :return string : Returns the satellite hostname
+
+    Environment Variable:
+
+    RHEV_SAT_HOST
+        This is set, if we are using internal RHEV Templates and VM for
+        upgrade.
+    SATELLITE_HOSTNAME
+        This is set, in case user provides his personal satellite for
+        upgrade.
+        """
+    return os.environ.get(
+        'RHEV_SAT_HOST',
+        os.environ.get('SATELLITE_HOSTNAME')
+    )

--- a/upgrade_tests/test_scenarios.py
+++ b/upgrade_tests/test_scenarios.py
@@ -1,0 +1,288 @@
+# -*- encoding: utf-8 -*-
+"""Test for Upgrade Scenario's
+
+:Requirement: Satellite upgrade
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: CLI
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+import os
+import time
+
+from automation_tools.satellite6 import hammer
+from fabric.api import env, execute, run, task
+from fauxfactory import gen_alpha
+from unittest2.case import TestCase
+
+from upgrade.helpers.docker import (
+    docker_execute_command,
+    refresh_subscriptions_on_docker_clients
+)
+from upgrade_tests import post_upgrade, pre_upgrade
+from upgrade_tests.helpers.scenarios import (
+    create_dict,
+    dockerize,
+    get_entity_data,
+    get_satellite_host,
+    rpm1,
+    rpm2
+)
+
+
+class ScenarioBug1429201(TestCase):
+    """This Class will serve as a whole scenario with pre-upgrade and
+    post-upgrade test-case.
+    Scenario test to verify if we can create a custom repository and consume it
+    via client then we alter the created custom repository and satellite
+    will be able to sync back the repo.
+    """
+    prd_name = 'ScenarioBug1429201' + gen_alpha()
+    repo_name = 'ScenarioBug1429201' + gen_alpha()
+    lc_name = 'ScenarioBug1429201' + gen_alpha()
+    ak_name = 'ScenarioBug1429201' + gen_alpha()
+    cv_name = 'ScenarioBug1429201' + gen_alpha()
+    docker_vm = os.environ.get('DOCKER_VM')
+    org_id = 1
+    sat_host = get_satellite_host()
+    file_path = '/var/www/html/pub/custom_repo/'
+    custom_repo = 'https://' + sat_host + '/pub/custom_repo/'
+    _, rpm1_name = os.path.split(rpm1)
+    _, rpm2_name = os.path.split(rpm2)
+
+    def setUp(self):
+        hammer.set_hammer_config()
+        env.host_string = self.sat_host
+        env.user = 'root'
+
+    @task
+    def create_repo(self):
+        """ Creates a custom yum repository, that will be synced to satellite
+        """
+        try:
+            run('rm -rf {0}'.format(self.file_path))
+            run('mkdir {0}'.format(self.file_path))
+        except OSError:
+            run('mkdir /var/www/html/pub/custom_repo')
+        run('wget {0} -P {1}'.format(rpm1, self.file_path))
+        run('createrepo --database {0}'.format(self.file_path))
+
+    @pre_upgrade
+    def test_pre_user_scenario_bug_1429201(self):
+        """This is pre-upgrade scenario test to verify if we can create a
+         custom repository and consume it via client
+
+         :id: 8fb8ec87-efa5-43ed-8cb3-960ef9cd6df2
+
+         :steps:
+             1. Create repository RepoFoo that you will later add to your
+                Satellite. This repository should contain PackageFoo-1.0.rpm
+             2. Install satellite 6.1
+             3. Create custom product ProductFoo pointing to repository RepoFoo
+             4. Sync RepoFoo
+             5. Create content view CVFoo
+             6. Add RepoFoo to CVFoo
+             7. Publish version 1 of CVFoo
+
+         :expectedresults: The client and product is created successfully
+
+         :BZ: 1429201
+         """
+        execute(self.create_repo, self, host=self.sat_host)
+        # End to End product + ak association
+        print hammer.hammer_product_create(self.prd_name, self.org_id)
+        print hammer.hammer_repository_create(
+            self.repo_name,
+            self.org_id,
+            self.prd_name,
+            self.custom_repo
+            )
+
+        print hammer.hammer(
+            'lifecycle-environment create --name "{0}" '
+            '--organization-id {1} --prior-id "{2}"'.format(
+                                                        self.lc_name,
+                                                        self.org_id,
+                                                        1
+                                                        )
+                )
+        print hammer.hammer_repository_synchronize(
+            self.repo_name,
+            self.org_id,
+            self.prd_name
+            )
+        print hammer.hammer_content_view_create(self.cv_name, self.org_id)
+        print hammer.hammer_content_view_add_repository(
+            self.cv_name,
+            self.org_id,
+            self.prd_name,
+            self.repo_name
+            )
+        print hammer.hammer_content_view_publish(self.cv_name, self.org_id)
+        latest_repo_version = hammer.get_latest_cv_version(self.cv_name)
+        lc_result = hammer.hammer(
+            '"{0}" info --name "{1}" --organization-id '
+            '{2}'.format('lifecycle-environment',
+                         self.lc_name,
+                         self.org_id
+                         )
+                                  )
+        lifecycle_id = hammer.get_attribute_value(
+            lc_result,
+            self.lc_name,
+            'id'
+            )
+        print hammer.hammer_content_view_promote_version(
+            self.cv_name,
+            latest_repo_version,
+            lifecycle_id,
+            self.org_id
+            )
+        print hammer.hammer_activation_key_create(
+            self.ak_name,
+            self.org_id,
+            self.cv_name,
+            self.lc_name
+            )
+        print hammer.hammer_activation_key_add_subscription(
+            self.ak_name,
+            self.org_id,
+            self.prd_name
+            )
+        time.sleep(5)
+        # Creating a rhel7 vm and subscribing to AK
+        container_ids = dockerize(self.ak_name, 'rhel7')
+        time.sleep(30)  # Subscription manager needs time to register
+        result = execute(
+            docker_execute_command,
+            container_ids.values()[0],
+            'yum list {0} | grep {0}'.format(self.rpm1_name.split('-')[0]),
+            host=self.docker_vm
+            )
+        # Info on created entities to assert the test case using hammer info
+        prd_info = hammer.hammer(
+            '"{0}" info --name "{1}" --organization-id '
+            '{2}'.format('product', self.prd_name, self.org_id)
+        )
+        self.assertEqual(
+            self.prd_name,
+            hammer.get_attribute_value(prd_info, self.prd_name, 'name')
+        )
+        self.assertIsNotNone(container_ids)
+        self.assertIn(self.repo_name, result.values()[0])
+        global_dict = {self.__class__.__name__: {
+            'prd_name': self.prd_name,
+            'ak_name': self.ak_name,
+            'repo_name': self.repo_name,
+            'container_ids': container_ids
+        }
+        }
+        create_dict(global_dict)
+
+    @post_upgrade
+    def test_post_user_scenario_bug_1429201(self):
+        """This is post-upgrade scenario test to verify if we can alter the
+        created custom repository and satellite will be able to sync back
+        the repo
+
+        :id: 9415c3e5-4699-462f-81bc-4143d8b820f1
+
+        :steps:
+            1. Remove PackageFoo-1.0.rpm from RepoFoo
+            2. Add PackageFoo-2.0.rpm to RepoFoo
+            3. Sync RepoFoo
+            4. Publish version 2 of CVFoo
+            5. Delete version 1 of CVFoo
+            6. run /etc/cron.weekly/katello-remove-orphans
+            7. Subscribe ClientA to CVFoo
+            8. Try to install PackageFoo-1.0.rpm on ClientA
+            9. Notice that yum thinks it's there based on the repo metadata
+               but then fails to download it with 404
+            10. Try to install PackageFoo-2.0.rpm
+
+        :expectedresults: The clients is present after upgrade and deleted
+            rpm is unable to be fetched, while new rpm is pulled and installed
+            on client
+
+        :BZ: 1429201
+        """
+        entity_data = get_entity_data(self.__class__.__name__)
+        run('wget {0} -P {1}'.format(rpm2, self.file_path))
+        run('rm -rf {0}'.format(self.file_path + self.rpm1_name))
+        run('createrepo --update {0}'.format(self.file_path))
+        # get entities from pickle
+        pkcl_ak_name = entity_data['ak_name']
+        container_ids = entity_data['container_ids']
+        repo_name = entity_data['repo_name']
+        prd_name = entity_data['prd_name']
+        cv_name, lc_name = hammer.hammer_determine_cv_and_env_from_ak(
+            pkcl_ak_name,
+            self.org_id
+        )
+        # Info on created entities to assert the test case using hammer info
+        ak_info = hammer.hammer(
+            '"{0}" info --name "{1}" --organization-id '
+            '{2}'.format('activation-key', pkcl_ak_name, self.org_id)
+        )
+        print hammer.hammer_repository_synchronize(
+            repo_name,
+            self.org_id,
+            prd_name
+        )
+        print hammer.hammer_content_view_publish(cv_name, self.org_id)
+        latest_repo_version = hammer.get_latest_cv_version(cv_name)
+
+        result = hammer.hammer(
+            '"{0}" info --name "{1}" --organization-id '
+            '{2}'.format('lifecycle-environment', lc_name, self.org_id)
+        )
+        lifecycle_id = hammer.get_attribute_value(result, lc_name, 'id')
+        print hammer.hammer_content_view_promote_version(
+            cv_name,
+            latest_repo_version,
+            lifecycle_id,
+            self.org_id
+        )
+
+        hammer.hammer(
+            'content-view remove --content-view-version-ids {0}'
+            ' --name "{1}" --organization-id {2}'.format(
+                latest_repo_version,
+                cv_name,
+                self.org_id
+            )
+        )
+        run('/etc/cron.weekly/katello-remove-orphans')
+        execute(refresh_subscriptions_on_docker_clients,
+                container_ids.values(),
+                host=self.docker_vm
+                )
+        time.sleep(30)  # Subscription manager needs time to register
+        result_fail = execute(
+            docker_execute_command,
+            container_ids.values()[0],
+            'yum list {0} | grep {0}'.format(self.rpm1_name.split('-')[0]),
+            quiet=True,
+            host=self.docker_vm
+        )  # should be error
+        result_pass = execute(
+            docker_execute_command,
+            container_ids.values()[0],
+            'yum install -y {0}'.format(self.rpm2_name.split('-')[0]),
+            host=self.docker_vm
+        )  # should be successful
+        self.assertEqual(
+            pkcl_ak_name,
+            hammer.get_attribute_value(ak_info, pkcl_ak_name, 'name')
+        )
+        self.assertIsNotNone(container_ids)
+        self.assertIn('Error', result_fail.values()[0])
+        self.assertIn('Complete', result_pass.values()[0])


### PR DESCRIPTION
Adding use cases tests, to be tested with the upgrade process.
This tends , to capture corner cases , that our traditional/functional testing tends to miss out.
This will ensure to configure entities/features/contents(CV's)/provision hosts , before upgrade do some transactions on it , aslo asserts this pre-upgarde.
After upgrade, we are able to interact with same entities/ features/hosts created pre-upgrade , perform sanity checks, add corner cases to those entities.
issue: https://github.com/SatelliteQE/automation-tools/issues/532

Refactored PR from https://github.com/SatelliteQE/automation-tools/pull/569