### PR TITLE
Remove unhelpfull yum debug level

### DIFF
--- a/upgrade/capsule.py
+++ b/upgrade/capsule.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from automation_tools import set_yum_debug_level, setup_capsule_firewall
+from automation_tools import setup_capsule_firewall
 from automation_tools.repository import enable_repos, disable_repos
 from automation_tools.satellite6.capsule import generate_capsule_certs
 from automation_tools.utils import distro_info, update_packages
@@ -96,7 +96,6 @@ def satellite6_capsule_upgrade(cap_host, sat_host):
     logger.highlight('\n========== CAPSULE UPGRADE =================\n')
     from_version = os.environ.get('FROM_VERSION')
     to_version = os.environ.get('TO_VERSION')
-    set_yum_debug_level()
     setup_capsule_firewall()
     major_ver = distro_info()[1]
     # Re-register Capsule for 6.2
@@ -180,7 +179,6 @@ def satellite6_capsule_zstream_upgrade():
                        'FROM and TO versions are not same!')
         sys.exit(1)
     major_ver = distro_info()[1]
-    set_yum_debug_level()
     if os.environ.get('CAPSULE_URL'):
         disable_repos('rhel-{0}-server-satellite-capsule-{1}-rpms'.format(
             major_ver, from_version))

--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -5,7 +5,6 @@ from upgrade_tests.helpers.existence import set_datastore
 from upgrade.helpers.tools import host_pings, reboot
 from automation_tools import (
     enable_ostree,
-    set_yum_debug_level,
     setup_satellite_firewall,
     subscribe,
     install_prerequisites
@@ -89,8 +88,6 @@ def satellite6_upgrade():
         logger.warning('Wrong Satellite Version Provided to upgrade to. '
                        'Provide one of 6.1, 6.2')
         sys.exit(1)
-    # Setting yum stdout log level to be less verbose
-    set_yum_debug_level()
     setup_satellite_firewall()
     run('rm -rf /etc/yum.repos.d/rhel-{optional,released}.repo')
     logger.info('Updating system packages ... ')
@@ -188,8 +185,6 @@ def satellite6_zstream_upgrade():
                        'FROM and TO versions are not same!')
         sys.exit(1)
     base_url = os.environ.get('BASE_URL')
-    # Setting yum stdout log level to be less verbose
-    set_yum_debug_level()
     setup_satellite_firewall()
     major_ver = distro_info()[1]
     # Following disables the old satellite repo and extra repos enabled


### PR DESCRIPTION
Removing the strategy of setting the yum debug level to be less verbose, As its affecting the verification and validation  of yum update packages in upgrade automation.

Due to which its difficult to know if anything goes wrong with package installation and updates.

Si simply removing it from upgrade.

closes #33 