### PR TITLE
Add missing python library requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 fauxfactory==2.0.9
+ovirt-engine-sdk-python==3.6.8.0
+python-novaclient
 
 # Get automation-tools from master
 git+https://github.com/SatelliteQE/automation-tools#egg=automation-tools


### PR DESCRIPTION
We have deleted some python library requirements in automation tools while removing upgrade code from automation-tools. So those python libraries are no longer getting installed and hence our upgrade job is failing with missing python libraries.

So adding those in our requirements.txt