### PR TITLE
Fix Tests failed due to attribute name changes during upgrade

### DIFF
--- a/upgrade_tests/test_existance_relations/test_activationkeys.py
+++ b/upgrade_tests/test_existance_relations/test_activationkeys.py
@@ -26,7 +26,7 @@ component = 'activation-key'
 aks_cv = compare_postupgrade(component, 'content view')
 aks_lc = compare_postupgrade(component, 'lifecycle environment')
 aks_name = compare_postupgrade(component, 'name')
-aks_hl = compare_postupgrade(component, 'host limit')
+aks_hl = compare_postupgrade(component, ('consumed', 'host limit'))
 
 
 # Tests

--- a/upgrade_tests/test_existance_relations/test_subscriptions.py
+++ b/upgrade_tests/test_existance_relations/test_subscriptions.py
@@ -17,13 +17,14 @@ upgrade
 
 :Upstream: No
 """
+import os
 import pytest
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
 component = 'subscription'
 sub_name = compare_postupgrade(component, 'name')
-sub_uuid = compare_postupgrade(component, 'uuid')
+sub_uuid = compare_postupgrade(component, ('id', 'uuid'))
 sub_support = compare_postupgrade(component, 'support')
 sub_qntity = compare_postupgrade(component, 'quantity')
 sub_consume = compare_postupgrade(component, 'consumed')
@@ -99,4 +100,7 @@ def test_positive_subscriptions_by_end_date(pre, post):
     :expectedresults: All subscriptions end date status should be retained post
         upgrade
     """
+    from_ver = os.environ.get('FROM_VERSION')
+    if from_ver == '6.1':
+        post = post.split('t')[0]
     assert pre == post


### PR DESCRIPTION
Some Upgrade Existance tests are failing due to attribute of entity is changed during upgrade.

Fixes:
1. Now the test case writer has an opportunity to mention the attribute names for 6.1, 6.2 in form of tuple, if they are different. 
e.g : id in 6.1 = uuid in 6.2, consumed in 6.1 == host limit in 6.2
2. Tests are fixed with fix 1 change and they are providing the intended result.