### PR TITLE
Fail parameterize test when attribute or entity is missing

### DIFF
--- a/upgrade_tests/test_existance_relations/test_capsules.py
+++ b/upgrade_tests/test_existance_relations/test_capsules.py
@@ -18,6 +18,7 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import run_to_upgrade
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -28,6 +29,7 @@ cap_url = compare_postupgrade(component, 'url')
 
 
 # Tests
+@run_to_upgrade('6.2')
 @pytest.mark.parametrize(
     "pre,post", cap_features, ids=pytest_ids(cap_features))
 def test_positive_capsules_by_features(pre, post):


### PR DESCRIPTION
There are tests which are getting errored due to non availability of particular entity of component or the attribute itself is missing postupgrade. Such test cases are Errored out.

Fix:
The fix is those tests have been moved to xFailed to pre-condition to run a test is not met.

Test-Fix:
Now the features test of capsule will run while running upgrade from 6.2 to next version only. As there is no such attribute 'features' in 6.1 for capsule.