### PR TITLE
Fix Wrong sat version to upgrade warning for 6.3 upgrade that aborts job

### DIFF
--- a/upgrade/runner.py
+++ b/upgrade/runner.py
@@ -50,27 +50,28 @@ def setup_products_for_upgrade(product, os_version):
     :param string os_version: The os version on which product is installed
         e.g: rhel6, rhel7
     """
-    sat_host = cap_hosts = clients6 = clients7 = None
-    logger.info('Setting up Satellite ....')
-    sat_host = satellite6_setup(os_version)
-    if product == 'capsule' or product == 'n-1' or product == 'longrun':
-        logger.info('Setting up Capsule ....')
-        cap_hosts = satellite6_capsule_setup(
-            sat_host, os_version, False if product == 'n-1' else True)
-    if product == 'client' or product == 'longrun':
-        logger.info('Setting up Clients ....')
-        clients6, clients7 = satellite6_client_setup()
-    setups_dict = {
-        'sat_host': sat_host,
-        'capsule_hosts': cap_hosts,
-        'clients6': clients6,
-        'clients7': clients7
-    }
-    create_setup_dict(setups_dict)
-    if os.environ.get('RUN_EXISTANCE_TESTS', 'false').lower() == 'true':
-        logger.info('Setting up preupgrade datastore for existance tests')
-        set_datastore('preupgrade')
-    return sat_host, cap_hosts, clients6, clients7
+    if check_necessary_env_variables_for_upgrade(product):
+        sat_host = cap_hosts = clients6 = clients7 = None
+        logger.info('Setting up Satellite ....')
+        sat_host = satellite6_setup(os_version)
+        if product == 'capsule' or product == 'n-1' or product == 'longrun':
+            logger.info('Setting up Capsule ....')
+            cap_hosts = satellite6_capsule_setup(
+                sat_host, os_version, False if product == 'n-1' else True)
+        if product == 'client' or product == 'longrun':
+            logger.info('Setting up Clients ....')
+            clients6, clients7 = satellite6_client_setup()
+        setups_dict = {
+            'sat_host': sat_host,
+            'capsule_hosts': cap_hosts,
+            'clients6': clients6,
+            'clients7': clients7
+        }
+        create_setup_dict(setups_dict)
+        if os.environ.get('RUN_EXISTANCE_TESTS', 'false').lower() == 'true':
+            logger.info('Setting up preupgrade datastore for existance tests')
+            set_datastore('preupgrade')
+        return sat_host, cap_hosts, clients6, clients7
 
 
 def product_upgrade(product):

--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -78,15 +78,15 @@ def satellite6_upgrade():
         URL for the compose repository
     TO_VERSION
         Satellite version to upgrade to and enable repos while upgrading.
-        e.g '6.1','6.2'
+        e.g '6.1','6.2', '6.3'
     """
     logger.highlight('\n========== SATELLITE UPGRADE =================\n')
     to_version = os.environ.get('TO_VERSION')
     rhev_sat_host = os.environ.get('RHEV_SAT_HOST')
     base_url = os.environ.get('BASE_URL')
-    if to_version not in ['6.1', '6.2']:
+    if to_version not in ['6.1', '6.2', '6.3']:
         logger.warning('Wrong Satellite Version Provided to upgrade to. '
-                       'Provide one of 6.1, 6.2')
+                       'Provide one of 6.1, 6.2, 6.3')
         sys.exit(1)
     setup_satellite_firewall()
     run('rm -rf /etc/yum.repos.d/rhel-{optional,released}.repo')


### PR DESCRIPTION
Fixes this issue:
```Wrong Satellite Version Provided to upgrade to. Provide one of 6.1, 6.2```