### PR TITLE
[Existance Tests] Update searach key to 'search' for 'filter by search' tests

### DIFF
--- a/upgrade_tests/test_existance_relations/test_filter.py
+++ b/upgrade_tests/test_existance_relations/test_filter.py
@@ -24,7 +24,7 @@ from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 # Required Data
 component = 'filter'
 fil_rtype = compare_postupgrade(component, 'resource type')
-fil_search = compare_postupgrade(component, 'resource type')
+fil_search = compare_postupgrade(component, 'search')
 fil_unlimited = compare_postupgrade(component, 'unlimited?')
 fil_role = compare_postupgrade(component, 'role')
 fil_perm = compare_postupgrade(component, 'permissions')


### PR DESCRIPTION
This fixes the copy paste error happened for test 'test_positive_filters_by_search' , as:
the key 'resource_type is used to fetch data instead of 'search' key.
