### PR TITLE
Fixes the timing issue, while disabling repos on capsule

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -31,6 +31,7 @@ from upgrade.helpers.tasks import (
 )
 from upgrade.helpers.tools import (
     copy_ssh_key,
+    disable_old_repos,
     get_hostname_from_ip,
     get_sat_cap_version,
     host_pings,

--- a/upgrade/capsule.py
+++ b/upgrade/capsule.py
@@ -1,9 +1,8 @@
 import os
 import sys
-import time
 
 from automation_tools import setup_capsule_firewall
-from automation_tools.repository import enable_repos, disable_repos
+from automation_tools.repository import enable_repos
 from automation_tools.satellite6.capsule import generate_capsule_certs
 from automation_tools.utils import distro_info, update_packages
 from datetime import datetime
@@ -17,6 +16,7 @@ from upgrade.helpers.tasks import (
 )
 from upgrade.helpers.tools import (
     copy_ssh_key,
+    disable_old_repos,
     reboot,
     host_pings,
     host_ssh_availability_check
@@ -122,9 +122,7 @@ def satellite6_capsule_upgrade(cap_host, sat_host):
             'CAPSULE_AK') else os.environ.get('RHEV_CAPSULE_AK')
         run('subscription-manager register --org="Default_Organization" '
             '--activationkey={0} --force'.format(ak_name))
-    run('subscription-manager refresh')
-    time.sleep(3)
-    disable_repos('rhel-{0}-server-satellite-capsule-{1}-rpms'.format(
+    disable_old_repos('rhel-{0}-server-satellite-capsule-{1}-rpms'.format(
         major_ver, from_version))
     if from_version == '6.1' and major_ver == '6':
         enable_repos('rhel-server-rhscl-{0}-rpms'.format(major_ver))
@@ -191,10 +189,8 @@ def satellite6_capsule_zstream_upgrade():
                        'FROM and TO versions are not same!')
         sys.exit(1)
     major_ver = distro_info()[1]
-    run('subscription-manager refresh')
-    time.sleep(3)
     if os.environ.get('CAPSULE_URL'):
-        disable_repos('rhel-{0}-server-satellite-capsule-{1}-rpms'.format(
+        disable_old_repos('rhel-{0}-server-satellite-capsule-{1}-rpms'.format(
             major_ver, from_version))
     # Check what repos are set
     run('yum repolist')

--- a/upgrade/helpers/tools.py
+++ b/upgrade/helpers/tools.py
@@ -127,6 +127,26 @@ def host_ssh_availability_check(host, timeout=7):
             time.sleep(5)
 
 
+def disable_old_repos(repo_name, timeout=1):
+    """This ensures that the repo is disable and the command doesn't timeout
+
+    :param repo_name: Repo ID of the repo to be disable
+    :param int timeout: The polling timeout in minutes.
+    """
+    timeup = time.time() + int(timeout) * 60
+    while True:
+        run('subscription-manager refresh')
+        repos = run('subscription-manager repos --list | grep \'Repo ID\'')
+        if time.time() > timeup:
+            logger.warning('There is no {0} repo to disable'.format(repo_name))
+            return False
+        if repos.__contains__(repo_name):
+            run('subscription-manager repos --disable {0}'.format(repo_name))
+            return True
+        else:
+            time.sleep(5)
+
+
 def get_hostname_from_ip(ip, timeout=3):
     """Retrives the hostname by logging into remote machine by IP.
     Specially for the systems who doesnt support reverse DNS.


### PR DESCRIPTION
Test:
```
fab -u root call
[cap.com] Executing task 'run_output'
[cap.com] run: subscription-manager refresh
[cap.com] out: All local data refreshed
[cap.com] out: 

[cap.com] run: subscription-manager repos --list | grep 'Repo ID'
[cap.com] out: Repo ID:   rhel-7-server-rpms
[cap.com] out: Repo ID:   Default_Organization_capsule6_latest_capsule6_latest_repo
[cap.com] out: Repo ID:   rhel-7-server-satellite-capsule-6.2-rpms
[cap.com] out: Repo ID:   rhel-server-rhscl-7-rpms
[cap.com] out: 

[cap.com] run: subscription-manager repos --disable rhel-7-server-satellite-capsule-6.2-rpms
[cap.com] out: Repository 'rhel-7-server-satellite-capsule-6.2-rpms' is disabled for this system.
[cap.com] out: 


Done.
Disconnecting from cap.com... done.
```