### PR TITLE
Wait for 6 minutes before upgrading capsule to 6.3

### DIFF
--- a/upgrade/runner.py
+++ b/upgrade/runner.py
@@ -4,9 +4,11 @@ Many commands are affected by environment variables. Unless stated otherwise,
 all environment variables are required.
 """
 import os
+import time
 
 from automation_tools import foreman_debug
 from automation_tools.satellite6.log import LogAnalyzer
+from robozilla.decorators import bz_bug_is_open
 from upgrade.capsule import (
     satellite6_capsule_setup,
     satellite6_capsule_upgrade,
@@ -192,6 +194,12 @@ def product_upgrade(product):
                 # Execute tasks as post upgrade tier1 tests are dependent
                 post_upgrade_test_tasks(sat_host)
                 if product == 'capsule' or product == 'longrun':
+                    # Wait for 6 minutes to get satellite ready after upgrading
+                    # to 6.3, So that capsule will connect to satellite.
+                    # The issue is observed in 6.3 and bz 1493046 is raised
+                    if to_version == '6.3':
+                        if bz_bug_is_open(1493046):
+                            time.sleep(370)
                     cap_hosts = setup_dict['capsule_hosts']
                     for cap_host in cap_hosts:
                         try:


### PR DESCRIPTION
This fixes the issue connecting to satellite from capsule, when satellite is upgraded to 6.3. As the Developers observed its an issue of slow starts on satellite with rails.