### PR TITLE
Add missing robozilla python package requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fauxfactory==2.0.9
 ovirt-engine-sdk-python==3.6.8.0
 python-novaclient
+robozilla
 
 # Get automation-tools from master
 git+https://github.com/SatelliteQE/automation-tools#egg=automation-tools

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
         'pytest',
         'python-bugzilla==1.2.2',
         'python-novaclient',
-        'requests'
+        'requests',
+        'robozilla'
     ],
     license='GNU GPL v3.0',
     classifiers=(


### PR DESCRIPTION
Satellite6-upgrade is mising robozilla python library, so added the same