### PR TITLE
Fail tests instead of xFail if the entity is missing

### DIFF
--- a/upgrade_tests/helpers/existence.py
+++ b/upgrade_tests/helpers/existence.py
@@ -299,9 +299,7 @@ def compare_postupgrade(component, attribute):
             culprit_ver = ' in preupgrade version' if 'missing' \
                 in preupgrade_entity else ' in postupgrade version'
             entity_values.append(
-                pytest.mark.xfail(
-                    (preupgrade_entity, postupgrade_entity),
-                    reason=culprit+culprit_ver))
+                pytest.fail(culprit+culprit_ver))
         else:
             entity_values.append((preupgrade_entity, postupgrade_entity))
     return entity_values


### PR DESCRIPTION
This change will let us know if any entities or attribute missing post upgrade.

As of now these missing's was xfails, but pytest junit-xml consider them as skipped test and hence thats the reason they were hiding from showing themselves as failure.

so the, Fix:
From now onwards they will be displayed as Errors.

Future:
I am trying my best to get them in failures but somehow I am not successful. Will continue to investigate on this and raise PR in future