### PR TITLE
Skip the tests with bz id

### DIFF
--- a/upgrade_tests/test_existance_relations/test_contenthosts.py
+++ b/upgrade_tests/test_existance_relations/test_contenthosts.py
@@ -18,6 +18,7 @@ post upgrade
 :Upstream: No
 """
 import pytest
+from robozilla.decorators import pytest_skip_if_bug_open
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -39,6 +40,7 @@ def test_positive_contenthosts_by_name(pre, post):
     assert pre == post
 
 
+@pytest_skip_if_bug_open('bugzilla', 1461397)
 @pytest.mark.parametrize("pre,post", ch_errata, ids=pytest_ids(ch_errata))
 def test_positive_installable_erratas_by_name(pre, post):
     """Test all content hosts installable erratas are existing after upgrade

--- a/upgrade_tests/test_existance_relations/test_contentviews.py
+++ b/upgrade_tests/test_existance_relations/test_contentviews.py
@@ -18,6 +18,8 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
+
+from robozilla.decorators import pytest_skip_if_bug_open
 from upgrade_tests.helpers.common import run_to_upgrade
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
@@ -30,6 +32,7 @@ cvs_name = compare_postupgrade(component, 'name')
 
 
 # Tests
+@pytest_skip_if_bug_open('bugzilla', 1461026)
 @pytest.mark.parametrize("pre,post", cvs_repo, ids=pytest_ids(cvs_repo))
 def test_positive_cvs_by_repository_ids(pre, post):
     """Test repository associations of all CVs post upgrade

--- a/upgrade_tests/test_existance_relations/test_hosts.py
+++ b/upgrade_tests/test_existance_relations/test_hosts.py
@@ -18,6 +18,7 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
+from robozilla.decorators import pytest_skip_if_bug_open
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -42,6 +43,7 @@ def test_positive_hosts_by_ip(pre, post):
     assert pre == post
 
 
+@pytest_skip_if_bug_open('bugzilla', 1289510)
 @pytest.mark.parametrize("pre,post", host_mac, ids=pytest_ids(host_mac))
 def test_positive_hosts_by_mac(pre, post):
     """Test mac associations of all hosts post upgrade

--- a/upgrade_tests/test_existance_relations/test_organizations.py
+++ b/upgrade_tests/test_existance_relations/test_organizations.py
@@ -18,6 +18,7 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
+from robozilla.decorators import pytest_skip_if_bug_open
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -64,6 +65,7 @@ def test_positive_organizations_by_label(pre, post):
     assert pre == post
 
 
+@pytest_skip_if_bug_open('bugzilla', 1461455)
 @pytest.mark.parametrize("pre,post", org_desc, ids=pytest_ids(org_desc))
 def test_positive_organizations_by_description(pre, post):
     """Test all organizations descriptions is retained post upgrade


### PR DESCRIPTION
We have decorator modified to suit pytest needs from robozilla repo.

This implementation helps to skip the tests which are affected by BZ
