### PR TITLE
Update api existence helpers and code in runner accordingly

### DIFF
--- a/upgrade/runner.py
+++ b/upgrade/runner.py
@@ -70,7 +70,8 @@ def setup_products_for_upgrade(product, os_version):
         create_setup_dict(setups_dict)
         if os.environ.get('RUN_EXISTANCE_TESTS', 'false').lower() == 'true':
             logger.info('Setting up preupgrade datastore for existance tests')
-            set_datastore('preupgrade')
+            set_datastore('preupgrade', 'cli')
+            set_datastore('preupgrade', 'api')
         return sat_host, cap_hosts, clients6, clients7
 
 

--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -158,7 +158,8 @@ def satellite6_upgrade():
         enable_ostree(sat_version='6.2')
     if os.environ.get('RUN_EXISTANCE_TESTS', 'false').lower() == 'true':
         logger.info('Setting up postupgrade datastore for existance tests..')
-        set_datastore('postupgrade')
+        set_datastore('postupgrade', 'cli')
+        set_datastore('postupgrade', 'api')
 
 
 def satellite6_zstream_upgrade():

--- a/upgrade_tests/helpers/existence.py
+++ b/upgrade_tests/helpers/existence.py
@@ -64,7 +64,7 @@ def set_api_server_config(user=None, passwd=None, verify=None):
     )
     url = 'https://{}'.format(env.get('satellite_host'))
     verify = False if not verify else verify
-    ServerConfig(auth=auth, url=url, verify=verify)
+    ServerConfig(auth=auth, url=url, verify=verify).save()
 
 
 def api_reader(component):
@@ -91,11 +91,10 @@ def api_reader(component):
     :param string component: Satellite component name. e.g host, capsule
     :returns dict: The dict repr of entities data of all components
     """
-    set_api_server_config()
     comp_data = {}
     comp_entity_data = []
-    comp_entity_list = api_const.api_components()[component][0].read_all()
-    for unique_id in comp_entity_list.results:
+    comp_entity_list = api_const.api_components()[component][0].search_json()
+    for unique_id in comp_entity_list['results']:
         single_entity_info = api_const.api_components(
             unique_id['id']
         )[component][1].read_json()
@@ -201,6 +200,7 @@ def set_datastore(datastore, endpoint):
         ]
         all_comps_data = nonorged_comps_data + orged_comps_data
     if endpoint == 'api':
+        set_api_server_config()
         api_comps = api_const.api_components().keys()
         all_comps_data = [
             api_reader(component) for component in api_comps


### PR DESCRIPTION
This fixes:
1. Set Datastore is updated with both endpoints temporarily, once we have full coverage from api, we will remove cli.
2. Set datastore is updated for both pre and post upgrade datastore.
3. The nailgun func search_json() is used instead of read_all() new method.
4. The nailgun config file is now saved which wasnt happening earlier and so the error of missing config file is now fixed.

Forjob build: look at standalone jobs 794th job it worked. The datastore are now getting created.