### PR TITLE
Refactored set datastore to support scenario tests

### DIFF
--- a/upgrade/runner.py
+++ b/upgrade/runner.py
@@ -21,7 +21,6 @@ from upgrade.satellite import (
     satellite6_upgrade,
     satellite6_zstream_upgrade
 )
-from upgrade_tests.helpers.existence import set_datastore
 from upgrade.helpers.logger import logger
 from upgrade.helpers.tasks import (
     check_necessary_env_variables_for_upgrade,
@@ -68,10 +67,6 @@ def setup_products_for_upgrade(product, os_version):
             'clients7': clients7
         }
         create_setup_dict(setups_dict)
-        if os.environ.get('RUN_EXISTANCE_TESTS', 'false').lower() == 'true':
-            logger.info('Setting up preupgrade datastore for existance tests')
-            set_datastore('preupgrade', 'cli')
-            set_datastore('preupgrade', 'api')
         return sat_host, cap_hosts, clients6, clients7
 
 

--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-from upgrade_tests.helpers.existence import set_datastore
 from upgrade.helpers.tools import (
     host_pings,
     host_ssh_availability_check,
@@ -156,10 +155,6 @@ def satellite6_upgrade():
     # Enable ostree feature only for rhel7 and sat6.2
     if to_version == '6.2' and major_ver == 7:
         enable_ostree(sat_version='6.2')
-    if os.environ.get('RUN_EXISTANCE_TESTS', 'false').lower() == 'true':
-        logger.info('Setting up postupgrade datastore for existance tests..')
-        set_datastore('postupgrade', 'cli')
-        set_datastore('postupgrade', 'api')
 
 
 def satellite6_zstream_upgrade():
@@ -237,6 +232,3 @@ def satellite6_zstream_upgrade():
     set_hammer_config()
     hammer('ping')
     run('katello-service status', warn_only=True)
-    if os.environ.get('RUN_EXISTANCE_TESTS', 'false').lower() == 'true':
-        logger.info('Setting up postupgrade datastore for existance tests')
-        set_datastore('postupgrade')

--- a/upgrade_tests/helpers/existence.py
+++ b/upgrade_tests/helpers/existence.py
@@ -10,8 +10,9 @@ from automation_tools.satellite6.hammer import (
     hammer,
     set_hammer_config
 )
-from fabric.api import env, execute
+from fabric.api import execute
 from nailgun.config import ServerConfig
+from upgrade.helpers.tools import get_setup_data
 from upgrade_tests.helpers.constants import api_const, cli_const
 
 
@@ -36,7 +37,7 @@ def csv_reader(component, subcommand):
     """
     comp_dict = {}
     entity_list = []
-    sat_host = env.get('satellite_host')
+    sat_host = get_setup_data()['sat_host']
     set_hammer_config()
     data = execute(
         hammer, '{0} {1}'.format(component, subcommand), 'csv', host=sat_host
@@ -58,11 +59,12 @@ def set_api_server_config(user=None, passwd=None, verify=None):
     :param bool verify: The ssl verification to connect to satellite host
         False by default if not provided
     """
+    sat_host = get_setup_data()['sat_host']
     auth = (
         'admin' if not user else user,
         'changeme' if not passwd else passwd
     )
-    url = 'https://{}'.format(env.get('satellite_host'))
+    url = 'https://{}'.format(sat_host)
     verify = False if not verify else verify
     ServerConfig(auth=auth, url=url, verify=verify).save()
 


### PR DESCRIPTION
The Data-store creation will be handled as a Fabric task, this helps make the framework to be more flexible and add scenario test support
Both PR's are dependent on each other. So both has to be merged
https://github.com/SatelliteQE/robottelo-ci/pull/884