### PR TITLE
Improved Existence Tests

### DIFF
--- a/upgrade_tests/helpers/common.py
+++ b/upgrade_tests/helpers/common.py
@@ -3,12 +3,64 @@
 import os
 import pytest
 
+from functools import partial
+from robozilla.decorators import pytest_skip_if_bug_open
+from upgrade_tests.helpers.variants import assert_varients
+
 cur_ver = os.environ.get('FROM_VERSION')
+to_ver = os.environ.get('TO_VERSION')
 
 
 class VersionException(Exception):
     """Version Exception if wrong satellite version provided"""
     pass
+
+
+pytest_skip_if_bug_open = partial(
+        pytest_skip_if_bug_open)
+
+
+def existence(pre, post, component=None):
+    """Returns test result according to pre and post value
+
+    Result Types:
+    ```
+    1. Fails the test with reason if 'missing' keyword found in pre or post
+    value
+    2. If 'component' is provided then it alternates the result of assert if
+    the value of entity attribute is 'expected' to change during upgrade.
+    visit def `assert_variants` for more details
+    3. Finally If nothing from above, then plain comparision and return results
+    ```
+
+    Note:
+    ```
+    If your are sure that the component attribute name varies between sat
+    versions, then Its mandatory to pass component parameter to this function
+    while calling.
+
+     e.g:
+     def test_anyentity(pre, post)
+        assert existence(pre, post, component='entity_name')
+    This internally calls assert_variants function.
+    ```
+
+    :param pre: Pre-upgrade value from test
+    :param post: Post-upgrade Value from test
+    :param component: The satellite component name for which the attribute name
+     differs
+    :return: Returns pytest.fail or Boolean value according to pre-upgrade and
+     post-upgrade value
+    """
+    if isinstance(pre, str) or isinstance(pre, int):
+        pre = str(pre)
+        post = str(post)
+    if ('missing' in pre) or ('missing' in post):
+            pytest.fail(msg='{0}{1}'.format(pre, post))
+    elif component:
+        return assert_varients(component, pre, post)
+    else:
+        return pre == post
 
 
 def run_to_upgrade(version):

--- a/upgrade_tests/helpers/existence.py
+++ b/upgrade_tests/helpers/existence.py
@@ -4,7 +4,6 @@ post upgrade
 import csv
 import json
 import os
-import pytest
 
 from automation_tools.satellite6.hammer import (
     hammer,
@@ -322,8 +321,7 @@ def compare_postupgrade(component, attribute):
                 else postupgrade_entity
             culprit_ver = ' in preupgrade version' if 'missing' \
                 in preupgrade_entity else ' in postupgrade version'
-            entity_values.append(
-                pytest.fail(culprit+culprit_ver))
+            entity_values.append((culprit, culprit_ver))
         else:
             entity_values.append((preupgrade_entity, postupgrade_entity))
     return entity_values

--- a/upgrade_tests/test_existance_relations/api/test_contentviews.py
+++ b/upgrade_tests/test_existance_relations/api/test_contentviews.py
@@ -18,6 +18,7 @@ post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -35,4 +36,4 @@ def test_positive_cv_by_chosts_count(pre, post):
     :expectedresults: Content Hosts of all CVs should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/api/test_domains.py
+++ b/upgrade_tests/test_existance_relations/api/test_domains.py
@@ -17,6 +17,7 @@
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -33,4 +34,4 @@ def test_positive_domains_by_subnet(pre, post):
 
     :expectedresults: Subnets of all domains should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/api/test_subnets.py
+++ b/upgrade_tests/test_existance_relations/api/test_subnets.py
@@ -17,6 +17,7 @@
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -34,4 +35,4 @@ def test_positive_subnet_by_network_address(pre, post):
     :expectedresults: Network Addresses of all subnets should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_activationkeys.py
+++ b/upgrade_tests/test_existance_relations/cli/test_activationkeys.py
@@ -18,6 +18,7 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 
@@ -39,7 +40,7 @@ def test_positive_aks_by_content_view(pre, post):
 
     :expectedresults: CV of all AKs should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", aks_lc, ids=pytest_ids(aks_lc))
@@ -50,7 +51,7 @@ def test_positive_aks_by_lc(pre, post):
 
     :expectedresults: LC of all AKs should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", aks_name, ids=pytest_ids(aks_name))
@@ -61,7 +62,7 @@ def test_positive_aks_by_name(pre, post):
 
     :expectedresults: AKs should be existing by their names post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", aks_hl, ids=pytest_ids(aks_hl))
@@ -73,4 +74,4 @@ def test_positive_aks_by_host_limit(pre, post):
     :expectedresults: Subscription consumptions by hosts of all AKs should be
         retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_architectures.py
+++ b/upgrade_tests/test_existance_relations/cli/test_architectures.py
@@ -18,6 +18,7 @@ post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -35,4 +36,4 @@ def test_positive_architectures_by_name(pre, post):
     :expectedresults: All architectures should be retained post upgrade by
         names
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_capsules.py
+++ b/upgrade_tests/test_existance_relations/cli/test_capsules.py
@@ -18,7 +18,7 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
-from upgrade_tests.helpers.common import run_to_upgrade
+from upgrade_tests.helpers.common import run_to_upgrade, existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -40,7 +40,7 @@ def test_positive_capsules_by_features(pre, post):
     :expectedresults: All features of all capsules should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", cap_name, ids=pytest_ids(cap_name))
@@ -51,7 +51,7 @@ def test_positive_capsules_by_name(pre, post):
 
     :expectedresults: All capsules should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", cap_url, ids=pytest_ids(cap_url))
@@ -63,4 +63,4 @@ def test_positive_capsules_by_url(pre, post):
     :expectedresults: Capsule urls of all capsules should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_computeresources.py
+++ b/upgrade_tests/test_existance_relations/cli/test_computeresources.py
@@ -18,6 +18,7 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -34,7 +35,7 @@ def test_positive_compute_resources_by_name(pre, post):
 
     :expectedresults: All compute resources should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize(
@@ -47,4 +48,4 @@ def test_positive_compute_resources_by_provider(pre, post):
     :expectedresults: All compute resources provider should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_contenthosts.py
+++ b/upgrade_tests/test_existance_relations/cli/test_contenthosts.py
@@ -18,6 +18,7 @@ post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from robozilla.decorators import pytest_skip_if_bug_open
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
@@ -37,7 +38,7 @@ def test_positive_contenthosts_by_name(pre, post):
     :expectedresults: All content hosts should be retained post upgrade by
         names
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest_skip_if_bug_open('bugzilla', 1461397)
@@ -50,4 +51,4 @@ def test_positive_installable_erratas_by_name(pre, post):
     :expectedresults: All chosts installable erratas should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_contentviews.py
+++ b/upgrade_tests/test_existance_relations/cli/test_contentviews.py
@@ -20,7 +20,7 @@ associations post upgrade
 import pytest
 
 from robozilla.decorators import pytest_skip_if_bug_open
-from upgrade_tests.helpers.common import run_to_upgrade
+from upgrade_tests.helpers.common import existence, run_to_upgrade
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -46,7 +46,7 @@ def test_positive_cvs_by_repository_ids(pre, post):
         pre = sorted([num.strip() for num in pre.split(',')])
     if ',' in post:
         post = sorted([num.strip() for num in post.split(',')])
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", cvs_label, ids=pytest_ids(cvs_label))
@@ -57,7 +57,7 @@ def test_positive_cvs_by_label(pre, post):
 
     :expectedresults: All CVs should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @run_to_upgrade('6.2')
@@ -70,7 +70,7 @@ def test_positive_cvs_by_composite_views(pre, post):
 
     :expectedresults: All composite CVs should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", cvs_name, ids=pytest_ids(cvs_name))
@@ -81,4 +81,4 @@ def test_positive_cvs_by_name(pre, post):
 
     :expectedresults: All CVs should be retained post upgrade by their name
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_discovery.py
+++ b/upgrade_tests/test_existance_relations/cli/test_discovery.py
@@ -19,6 +19,7 @@ its relations post upgrade
 """
 import os
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -43,7 +44,7 @@ def test_positive_discovery_by_name(pre, post):
     :expectedresults: All architectures should be retained post upgrade by
         names
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", dis_mac, ids=pytest_ids(dis_mac))
@@ -54,7 +55,7 @@ def test_positive_discovery_by_mac(pre, post):
 
     :expectedresults: All discovered hosts mac should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", dis_cpus, ids=pytest_ids(dis_cpus))
@@ -65,7 +66,7 @@ def test_positive_discovery_by_cpus(pre, post):
 
     :expectedresults: All discovered hosts cpus should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", dis_mem, ids=pytest_ids(dis_mem))
@@ -77,7 +78,7 @@ def test_positive_discovery_by_memory(pre, post):
     :expectedresults: All discovered hosts memory allocation should be retained
         post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", dis_disks, ids=pytest_ids(dis_disks))
@@ -89,7 +90,7 @@ def test_positive_discovery_by_disc_counts(pre, post):
     :expectedresults: All discovered hosts disk counts should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", dis_size, ids=pytest_ids(dis_size))
@@ -101,7 +102,7 @@ def test_positive_discovery_by_disc_size(pre, post):
     :expectedresults: All discovered hosts disk size should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", dis_subnet, ids=pytest_ids(dis_subnet))
@@ -115,4 +116,4 @@ def test_positive_discovery_by_subnet(pre, post):
     """
     if to_version == '6.3':
         post = post.split(' (')[0]
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_discoveryrulels.py
+++ b/upgrade_tests/test_existance_relations/cli/test_discoveryrulels.py
@@ -18,6 +18,7 @@ its associations post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -40,8 +41,7 @@ def test_positive_discovery_rules_by_name(pre, post):
     :expectedresults: All discovery rules should be retained post upgrade by
         names
     """
-    print pre if pre else "OMG"
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", drule_prio, ids=pytest_ids(drule_prio))
@@ -53,7 +53,7 @@ def test_positive_discovery_rules_by_priority(pre, post):
     :expectedresults: All discovery rules priorities should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize(
@@ -66,7 +66,7 @@ def test_positive_discovery_rules_by_search(pre, post):
     :expectedresults: All discovery rules search should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", drule_hg, ids=pytest_ids(drule_hg))
@@ -79,7 +79,7 @@ def test_positive_discovery_rules_by_hostgroup(pre, post):
     :expectedresults: All discovery rules hostgroups should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", drule_hl, ids=pytest_ids(drule_hl))
@@ -91,7 +91,7 @@ def test_positive_discovery_rules_by_hostslimit(pre, post):
     :expectedresults: All discovery rules hosts limit should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize(
@@ -105,4 +105,4 @@ def test_positive_discovery_rules_by_enablement(pre, post):
     :expectedresults: All discovery rules enablement and disablement should be
         retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_domains.py
+++ b/upgrade_tests/test_existance_relations/cli/test_domains.py
@@ -17,6 +17,7 @@
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -33,4 +34,4 @@ def test_positive_domains_by_name(pre, post):
 
     :expectedresults: All domains should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_filter.py
+++ b/upgrade_tests/test_existance_relations/cli/test_filter.py
@@ -18,8 +18,8 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
-from upgrade_tests.helpers.variants import assert_varients
 
 # Required Data
 component = 'filter'
@@ -40,7 +40,7 @@ def test_positive_filters_by_resource_type(pre, post):
     :expectedresults: All filters of all roles should be retained post upgrade
         by resource types
     """
-    assert assert_varients(component, pre, post)
+    assert existence(pre, post, component)
 
 
 @pytest.mark.parametrize("pre,post", fil_search, ids=pytest_ids(fil_search))
@@ -52,7 +52,7 @@ def test_positive_filters_by_search(pre, post):
     :expectedresults: All filters search criteria should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize(
@@ -65,7 +65,7 @@ def test_positive_filters_by_unlimited_check(pre, post):
     :expectedresults: All filters unlimited criteria should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", fil_role, ids=pytest_ids(fil_role))
@@ -77,7 +77,7 @@ def test_positive_filters_by_role(pre, post):
     :expectedresults: All filters association with role should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", fil_perm, ids=pytest_ids(fil_perm))
@@ -89,4 +89,4 @@ def test_positive_filters_by_permissions(pre, post):
     :expectedresults: All filters all permissions should be retained post
         upgrade
     """
-    assert assert_varients(component, pre, post)
+    assert existence(pre, post, component)

--- a/upgrade_tests/test_existance_relations/cli/test_gpg.py
+++ b/upgrade_tests/test_existance_relations/cli/test_gpg.py
@@ -17,6 +17,7 @@
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -33,4 +34,4 @@ def test_positive_gpg_keys_by_name(pre, post):
 
     :expectedresults: All gpg keys should be retained post upgrade by names
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_hostgroups.py
+++ b/upgrade_tests/test_existance_relations/cli/test_hostgroups.py
@@ -18,6 +18,7 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -36,7 +37,7 @@ def test_positive_hostgroups_by_name(pre, post):
 
     :expectedresults: All hostgroups should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", hg_os, ids=pytest_ids(hg_os))
@@ -48,7 +49,7 @@ def test_positive_hostgroups_by_os(pre, post):
     :expectedresults: OS associations of all hostgroups should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", hg_lc, ids=pytest_ids(hg_lc))
@@ -60,4 +61,4 @@ def test_positive_hostgroups_by_lc(pre, post):
     :expectedresults: LC associations of all hostgroups should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_hosts.py
+++ b/upgrade_tests/test_existance_relations/cli/test_hosts.py
@@ -19,6 +19,7 @@ associations post upgrade
 """
 import pytest
 from robozilla.decorators import pytest_skip_if_bug_open
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -40,7 +41,7 @@ def test_positive_hosts_by_ip(pre, post):
     :expectedresults: IP of each host should be associated to its respective
         host post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest_skip_if_bug_open('bugzilla', 1289510)
@@ -53,7 +54,7 @@ def test_positive_hosts_by_mac(pre, post):
     :expectedresults: MAC of each host should be associated to its respective
         host post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", host_hg, ids=pytest_ids(host_hg))
@@ -65,7 +66,7 @@ def test_positive_hosts_by_hostgroup(pre, post):
     :expectedresults: HostGroup of each host should be associated to its
         respective host post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", host_os, ids=pytest_ids(host_os))
@@ -77,7 +78,7 @@ def test_positive_hosts_by_operating_system(pre, post):
     :expectedresults: OS of each host should be associated to its respective
         host post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", host_name, ids=pytest_ids(host_name))
@@ -88,4 +89,4 @@ def test_positive_hosts_by_name(pre, post):
 
     :expectedresults: All hosts should be retained post upgrade by their names
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_lifecycleenvs.py
+++ b/upgrade_tests/test_existance_relations/cli/test_lifecycleenvs.py
@@ -18,6 +18,7 @@ post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -35,4 +36,4 @@ def test_positive_lifecycle_envs_by_name(pre, post):
     :expectedresults: All lifecycle envs should be retained post upgrade by
         names
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_mediums.py
+++ b/upgrade_tests/test_existance_relations/cli/test_mediums.py
@@ -18,6 +18,7 @@ post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -34,4 +35,4 @@ def test_positive_mediums_by_name(pre, post):
 
     :expectedresults: All OS mediums should be retained post upgrade by names
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_organizations.py
+++ b/upgrade_tests/test_existance_relations/cli/test_organizations.py
@@ -18,6 +18,7 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from robozilla.decorators import pytest_skip_if_bug_open
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
@@ -38,7 +39,7 @@ def test_positive_organizations_by_id(pre, post):
 
     :expectedresults: All organizations should be retained post upgrade by id's
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", org_name, ids=pytest_ids(org_name))
@@ -50,7 +51,7 @@ def test_positive_organizations_by_name(pre, post):
     :expectedresults: All organizations should be retained post upgrade by
         names
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", org_label, ids=pytest_ids(org_label))
@@ -62,7 +63,7 @@ def test_positive_organizations_by_label(pre, post):
     :expectedresults: All organizations should be retained post upgrade by
         labels
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest_skip_if_bug_open('bugzilla', 1461455)
@@ -75,4 +76,4 @@ def test_positive_organizations_by_description(pre, post):
     :expectedresults: All organizations descriptions should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_os.py
+++ b/upgrade_tests/test_existance_relations/cli/test_os.py
@@ -17,6 +17,7 @@
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -34,7 +35,7 @@ def test_positive_os_by_title(pre, post):
 
     :expectedresults: All OS should be retained post upgrade by their title
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", os_fam, ids=pytest_ids(os_fam))
@@ -45,4 +46,4 @@ def test_positive_os_by_family(pre, post):
 
     :expectedresults: All OS should be retained post upgrade by their families
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_product.py
+++ b/upgrade_tests/test_existance_relations/cli/test_product.py
@@ -18,6 +18,7 @@ post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -35,7 +36,7 @@ def test_positive_products_by_name(pre, post):
 
     :expectedresults: All products should be retained post upgrade by names
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", prod_repo, ids=pytest_ids(prod_repo))
@@ -48,4 +49,4 @@ def test_positive_products_by_repositories(pre, post):
     :expectedresults: Repositories of all products should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_ptables.py
+++ b/upgrade_tests/test_existance_relations/cli/test_ptables.py
@@ -18,6 +18,7 @@ post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -35,4 +36,4 @@ def test_positive_partition_tables_by_name(pre, post):
     :expectedresults: All architectures should be retained post upgrade by
         names
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_puppet_module_class.py
+++ b/upgrade_tests/test_existance_relations/cli/test_puppet_module_class.py
@@ -18,6 +18,7 @@ existence post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -37,7 +38,7 @@ def test_positive_puppet_classes_by_name(pre, post):
     :expectedresults: All puppet classes should be retained post upgrade by
         names
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", pm_name, ids=pytest_ids(pm_name))
@@ -49,4 +50,4 @@ def test_positive_puppet_modules_by_name(pre, post):
     :expectedresults: All puppet modules should be retained post upgrade by
         names
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_puppetenvironment.py
+++ b/upgrade_tests/test_existance_relations/cli/test_puppetenvironment.py
@@ -18,6 +18,7 @@ post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -34,4 +35,4 @@ def test_positive_puppet_envs_by_name(pre, post):
 
     :expectedresults: All puppet envs should be retained post upgrade by names
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_repository.py
+++ b/upgrade_tests/test_existance_relations/cli/test_repository.py
@@ -18,6 +18,7 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -36,7 +37,7 @@ def test_positive_repositories_by_name(pre, post):
 
     :expectedresults: All repositories should be retained post upgrade by names
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", repo_prod, ids=pytest_ids(repo_prod))
@@ -49,7 +50,7 @@ def test_positive_repositories_by_product(pre, post):
     :expectedresults: All repositories association to its product should be
         retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", repo_ctype, ids=pytest_ids(repo_ctype))
@@ -60,4 +61,4 @@ def test_positive_repositories_by_url(pre, post):
 
     :expectedresults: All repositories urls should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_roles.py
+++ b/upgrade_tests/test_existance_relations/cli/test_roles.py
@@ -17,6 +17,7 @@
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -33,4 +34,4 @@ def test_positive_roles_by_name(pre, post):
 
     :expectedresults: All roles should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_scparams.py
+++ b/upgrade_tests/test_existance_relations/cli/test_scparams.py
@@ -18,7 +18,7 @@
 :Upstream: No
 """
 import pytest
-from upgrade_tests.helpers.common import run_to_upgrade
+from upgrade_tests.helpers.common import run_to_upgrade, existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 
@@ -40,7 +40,7 @@ def test_positive_smart_params_by_name(pre, post):
     :expectedresults: All smart parameters should be retained post upgrade by
         names
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", scp_dval, ids=pytest_ids(scp_dval))
@@ -52,7 +52,7 @@ def test_positive_smart_params_by_default_value(pre, post):
     :expectedresults: All smart parameters default values should be retained
         post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", scp_ovrde, ids=pytest_ids(scp_ovrde))
@@ -64,7 +64,7 @@ def test_positive_smart_params_by_override(pre, post):
     :expectedresults: All smart parameters override check should be retained
         post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @run_to_upgrade('6.2')
@@ -78,4 +78,4 @@ def test_positive_smart_params_by_puppet_class(pre, post):
     :expectedresults: All smart parameters associations with puppet classes
         should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_settings.py
+++ b/upgrade_tests/test_existance_relations/cli/test_settings.py
@@ -17,9 +17,9 @@
 :Upstream: No
 """
 import pytest
-from upgrade_tests.helpers.common import run_to_upgrade
+from upgrade_tests.helpers.common import run_to_upgrade, existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
-from upgrade_tests.helpers.variants import assert_varients
+
 # Required Data
 component = 'settings'
 sett_name = compare_postupgrade(component, 'name')
@@ -37,7 +37,7 @@ def test_positive_settings_by_name(pre, post):
 
     :expectedresults: All settings should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @run_to_upgrade('6.2')
@@ -49,7 +49,7 @@ def test_positive_settings_by_value(pre, post):
 
     :expectedresults: All settings values should be retained post upgrade
     """
-    assert assert_varients(component, pre, post)
+    assert existence(pre, post, component=component)
 
 
 @run_to_upgrade('6.2')
@@ -61,4 +61,4 @@ def test_positive_settings_by_description(pre, post):
 
     :expectedresults: All settings descriptions should be retained post upgrade
     """
-    assert assert_varients(component, pre, post)
+    assert existence(pre, post, component=component)

--- a/upgrade_tests/test_existance_relations/cli/test_smartvariables.py
+++ b/upgrade_tests/test_existance_relations/cli/test_smartvariables.py
@@ -18,7 +18,7 @@ and associations post upgrade
 :Upstream: No
 """
 import pytest
-from upgrade_tests.helpers.common import run_to_upgrade
+from upgrade_tests.helpers.common import existence, run_to_upgrade
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -40,7 +40,7 @@ def test_positive_smart_variables_by_name(pre, post):
     :expectedresults: All smart variables should be retained post upgrade by
         names
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @run_to_upgrade('6.2')
@@ -53,7 +53,7 @@ def test_positive_smart_variables_by_default_value(pre, post):
     :expectedresults: All smart variables default values should be retained
         post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @run_to_upgrade('6.2')
@@ -66,7 +66,7 @@ def test_positive_smart_variables_by_type(pre, post):
     :expectedresults: All smart variables override check should be retained
         post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @run_to_upgrade('6.2')
@@ -80,4 +80,4 @@ def test_positive_smart_variables_by_puppet_class(pre, post):
     :expectedresults: All smart variables associations with puppet classes
         should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_subnets.py
+++ b/upgrade_tests/test_existance_relations/cli/test_subnets.py
@@ -18,6 +18,7 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -36,7 +37,7 @@ def test_positive_subnets_by_name(pre, post):
 
     :expectedresults: All subnets should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", sub_network, ids=pytest_ids(sub_network))
@@ -47,7 +48,7 @@ def test_positive_subnets_by_network(pre, post):
 
     :expectedresults: All subnets network ip's should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", sub_mask, ids=pytest_ids(sub_mask))
@@ -58,4 +59,4 @@ def test_positive_subnets_by_mask(pre, post):
 
     :expectedresults: All subnets masks should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_subscriptions.py
+++ b/upgrade_tests/test_existance_relations/cli/test_subscriptions.py
@@ -19,8 +19,8 @@ upgrade
 """
 import os
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
-from upgrade_tests.helpers.variants import assert_varients
 
 # Required Data
 component = 'subscription'
@@ -42,7 +42,7 @@ def test_positive_subscriptions_by_name(pre, post):
     :expectedresults: All subscriptions should be retained post upgrade by
         names
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", sub_uuid, ids=pytest_ids(sub_uuid))
@@ -53,7 +53,7 @@ def test_positive_subscriptions_by_uuid(pre, post):
 
     :expectedresults: All subscriptions uuids should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", sub_support, ids=pytest_ids(sub_support))
@@ -65,7 +65,7 @@ def test_positive_subscriptions_by_support(pre, post):
     :expectedresults: All subscriptions support status should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", sub_qntity, ids=pytest_ids(sub_qntity))
@@ -77,7 +77,7 @@ def test_positive_subscriptions_by_quantity(pre, post):
     :expectedresults: All subscriptions quantities should be retained post
         upgrade
     """
-    assert assert_varients(component, pre, post)
+    assert existence(pre, post, component)
 
 
 @pytest.mark.parametrize("pre,post", sub_consume, ids=pytest_ids(sub_consume))
@@ -89,7 +89,7 @@ def test_positive_subscriptions_by_consumed(pre, post):
     :expectedresults: All subscriptions consumed status should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", sub_edate, ids=pytest_ids(sub_edate))
@@ -109,4 +109,4 @@ def test_positive_subscriptions_by_end_date(pre, post):
         pre = ' '.join(
             [splited_pre[0].replace('-', '/'), splited_pre[1].split('.')[0]]
         )
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_syncplan.py
+++ b/upgrade_tests/test_existance_relations/cli/test_syncplan.py
@@ -18,6 +18,7 @@ association post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -37,7 +38,7 @@ def test_positive_syncplans_by_name(pre, post):
 
     :expectedresults: All sync plans should be retained post upgrade by names
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", sp_sd, ids=pytest_ids(sp_sd))
@@ -48,7 +49,7 @@ def test_positive_syncplans_by_start_date(pre, post):
 
     :expectedresults: All sync plans start date should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", sp_interval, ids=pytest_ids(sp_interval))
@@ -60,7 +61,7 @@ def test_positive_syncplans_by_interval(pre, post):
     :expectedresults: All sync plans interval time should be retained post
         upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", sp_enable, ids=pytest_ids(sp_enable))
@@ -72,4 +73,4 @@ def test_positive_syncplans_by_enablement(pre, post):
     :expectedresults: All sync plans enablement and disablement should be
         retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_template.py
+++ b/upgrade_tests/test_existance_relations/cli/test_template.py
@@ -18,6 +18,7 @@ post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -34,4 +35,4 @@ def test_positive_templates_by_name(pre, post):
 
     :expectedresults: All templates should be retained post upgrade by names
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_usergroup.py
+++ b/upgrade_tests/test_existance_relations/cli/test_usergroup.py
@@ -18,6 +18,7 @@ post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -34,4 +35,4 @@ def test_positive_usergroups_by_name(pre, post):
 
     :expectedresults: All user groups should be retained post upgrade by names
     """
-    assert pre == post
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_users.py
+++ b/upgrade_tests/test_existance_relations/cli/test_users.py
@@ -18,6 +18,7 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
+from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -36,7 +37,7 @@ def test_positive_users_by_name(pre, post):
 
     :expectedresults: All users should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", user_login, ids=pytest_ids(user_login))
@@ -47,7 +48,7 @@ def test_positive_users_by_login(pre, post):
 
     :expectedresults: All users login name should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)
 
 
 @pytest.mark.parametrize("pre,post", user_email, ids=pytest_ids(user_email))
@@ -58,4 +59,4 @@ def test_positive_users_by_email(pre, post):
 
     :expectedresults: All users email should be retained post upgrade
     """
-    assert pre == post
+    assert existence(pre, post)


### PR DESCRIPTION
This PR improves:

1. ```Fail``` the test if the entity is missing. (Earlier it was xfail which was becoming skip in Jenkins and hence we were losing the actual number of failed tests)
2. Fail test case if the entity is missing for ```each``` parameter in parametrize (Earlier if the one parameter fails the remaining parameters were being skipped)
3. ```Fix```, the test is not getting skipped if the skipped with bug somehow.
4. Skip the test if the test is not marked for that satellite release, It was not working earlier due to point 1 above.

New:

1. New ```existence``` function does it all for you. (where all = dynamic assertion)
2. Roll out of existence function all over the test modules.