### PR TITLE
Disable foreman-maintain for 6.4

### DIFF
--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -93,13 +93,13 @@ def satellite6_upgrade():
     logger.highlight('\n========== SATELLITE UPGRADE =================\n')
     to_version = os.environ.get('TO_VERSION')
     base_url = os.environ.get('BASE_URL')
-    if to_version not in ['6.1', '6.2', '6.3']:
+    if to_version not in ['6.1', '6.2', '6.3', '6.4']:
         logger.warning('Wrong Satellite Version Provided to upgrade to. '
-                       'Provide one of 6.1, 6.2, 6.3')
+                       'Provide one of 6.1, 6.2, 6.3, 6.4')
         sys.exit(1)
     major_ver = distro_info()[1]
     if os.environ.get('PERFORM_FOREMAN_MAINTAIN_UPGRADE') == 'true' \
-            and os.environ.get('OS') == 'rhel7':
+            and os.environ.get('OS') == 'rhel7' and to_version != '6.4':
         if base_url is None:
             os.environ['DISTRIBUTION'] = "CDN"
         else:


### PR DESCRIPTION
As 6.4 target version is not added in foreman-maintain latest version. Till then use normal way of upgrading satellite. Will file an issue for revert change once foreman-maintain has 6.4 target version available. Here is the BZ raised https://bugzilla.redhat.com/show_bug.cgi?id=1570012