### PR TITLE
Fix Upgrade Existence Tests failures for 6.3 - Part 1 & 6.4 support

### DIFF
--- a/upgrade_tests/helpers/common.py
+++ b/upgrade_tests/helpers/common.py
@@ -56,7 +56,7 @@ def existence(pre, post, component=None):
         pre = str(pre)
         post = str(post)
     if ('missing' in pre) or ('missing' in post):
-            pytest.fail(msg='{0}{1}'.format(pre, post))
+        pytest.fail(msg='{0}{1}'.format(pre, post))
     elif component:
         return assert_varients(component, pre, post)
     else:

--- a/upgrade_tests/helpers/constants.py
+++ b/upgrade_tests/helpers/constants.py
@@ -1,8 +1,11 @@
 """API and CLI upgrade Tests Constants"""
+import os
+
 from nailgun import entities
 
 # FAKE REPOS
 FAKE_REPO_ZOO3 = 'http://inecas.fedorapeople.org/fakerepos/zoo3/'
+to_version = os.environ.get('TO_VERSION')
 
 
 class cli_const:
@@ -18,7 +21,8 @@ class cli_const:
             'capsule',
             'compute-resource',
             'discovery',
-            'discovery_rule',
+            'discovery-rule' if to_version in [
+                '6.3', '6.4'] else 'discovery_rule',
             'domain',
             'environment',
             'filter',

--- a/upgrade_tests/helpers/existence.py
+++ b/upgrade_tests/helpers/existence.py
@@ -41,7 +41,7 @@ def csv_reader(component, subcommand):
     data = execute(
         hammer, '{0} {1}'.format(component, subcommand), 'csv', host=sat_host
     )[sat_host]
-    csv_read = csv.DictReader(str(data.encode('utf-8')).lower().split('\n'))
+    csv_read = csv.DictReader(data.lower().split('\n'))
     for row in csv_read:
         entity_list.append(row)
     comp_dict[component] = entity_list
@@ -189,14 +189,13 @@ def set_datastore(datastore, endpoint):
         raise IncorrectEndpointException(
             'Endpoints has to be one of {}'.format(allowed_ends))
     if endpoint == 'cli':
-        org = os.environ.get('ORGANIZATION', 'Default_Organization')
         nonorged_comps_data = [
             csv_reader(
                 component, 'list') for component in cli_const.components[
                 'org_not_required']]
         orged_comps_data = [
             csv_reader(
-                component, 'list --organization {}'.format(org)
+                component, 'list --organization-id 1'
                 ) for component in cli_const.components['org_required']
         ]
         all_comps_data = nonorged_comps_data + orged_comps_data

--- a/upgrade_tests/helpers/variants.py
+++ b/upgrade_tests/helpers/variants.py
@@ -21,19 +21,22 @@ class VersionError(Exception):
 #
 # Note: The variants should be listed from 6.1 onwards
 _entity_varients = {
-    # Filter component variants
     'filter': [
-        ['lookupkey', 'variablelookupkey'],
-        ['(miscellaneous)', 'foremanopenscap::arfreport'],
-        ['organization', 'katello::subscription'],
-        ['configtemplate', 'provisioningtemplate'],
+        # Resource Type Variants
+        ['lookupkey', 'variablelookupkey', 'variablelookupkey'],
+        ['(miscellaneous)', 'foremanopenscap::arfreport',
+         'foremanopenscap::arfreport'],
+        ['organization', 'katello::subscription', 'katello::subscription'],
+        ['configtemplate', 'provisioningtemplate', 'provisioningtemplate'],
+        # Permissions Variants
         ['view_templates, create_templates, edit_templates, '
          'destroy_templates, deploy_templates',
          'view_provisioning_templates, create_provisioning_templates, '
          'edit_provisioning_templates, destroy_provisioning_templates, '
-         'deploy_provisioning_templates']
-    ],
-    # Setting Component variants
+         'deploy_provisioning_templates',
+         'view_provisioning_templates, create_provisioning_templates, '
+         'edit_provisioning_templates, destroy_provisioning_templates, '
+         'deploy_provisioning_templates']],
     'settings': [
         # Value Variants
         ['immediate', 'immediate', 'on_demand'],
@@ -92,12 +95,10 @@ _entity_varients = {
          ' machines and dns records may also be deleted.'],
         ['private key that foreman will use to encrypt websockets',
          'private key that foreman will use to encrypt websockets',
-         'private key file that foreman will use to encrypt websockets']
-    ],
-    # Subscription component Variants
+         'private key file that foreman will use to encrypt websockets']],
     'subscription': [
-        ['-1', '-1', 'unlimited']
-    ]
+        # Validity Variants
+        ['-1', '-1', 'unlimited']]
 }
 
 

--- a/upgrade_tests/test_existance_relations/cli/test_discovery.py
+++ b/upgrade_tests/test_existance_relations/cli/test_discovery.py
@@ -32,6 +32,7 @@ dis_disks = compare_postupgrade(component, 'disk count')
 dis_size = compare_postupgrade(component, 'disks size')
 dis_subnet = compare_postupgrade(component, 'subnet')
 to_version = os.environ.get('TO_VERSION')
+from_version = os.environ.get('FROM_VERSION')
 
 
 # Tests
@@ -114,6 +115,6 @@ def test_positive_discovery_by_subnet(pre, post):
     :expectedresults: All discovered hosts subnet should be retained post
         upgrade
     """
-    if to_version == '6.3':
-        post = post.split(' (')[0]
+    post = post.split(' (')[0] if to_version == '6.3' else post
+    pre = post.split(' (')[0] if from_version == '6.3' else pre
     assert existence(pre, post)


### PR DESCRIPTION
1. Fixes nitpicks
2. Fix updated component names for 6.3
3. Fixes the data not being fetched for components with organization
4. Fixes entity missing variants for 6.3 specially for filter entity
5. small test_discovery fix for 6.3 z-stream

Also the 6.4 support for existence tests is added.