### PR TITLE
Added task to upgrade puppet

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -31,7 +31,8 @@ from upgrade.helpers.tasks import (
     sync_capsule_repos_to_upgrade,
     sync_tools_repos_to_upgrade,
     setup_foreman_maintain,
-    upgrade_using_foreman_maintain
+    upgrade_using_foreman_maintain,
+    upgrade_puppet3_to_puppet4
 )
 from upgrade.helpers.tools import (
     copy_ssh_key,


### PR DESCRIPTION
This task will help to upgrade satellite 6.3 from puppet3 to puppet4. 
The plan is to utilize this task for customer-db upgrade automation as well as in standalone upgrader.