### PR TITLE
Added task for satellite-clone installation

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -31,6 +31,7 @@ from upgrade.helpers.tasks import (
     sync_capsule_repos_to_upgrade,
     sync_tools_repos_to_upgrade,
     setup_foreman_maintain,
+    setup_satellite_clone,
     upgrade_using_foreman_maintain,
     upgrade_puppet3_to_puppet4
 )

--- a/upgrade/runner.py
+++ b/upgrade/runner.py
@@ -49,6 +49,7 @@ def setup_products_for_upgrade(product, os_version):
     :param string os_version: The os version on which product is installed
         e.g: rhel6, rhel7
     """
+    env.disable_known_hosts = True
     if check_necessary_env_variables_for_upgrade(product):
         sat_host = cap_hosts = clients6 = clients7 = None
         logger.info('Setting up Satellite ....')
@@ -156,6 +157,7 @@ def product_upgrade(product):
     RHEV_CLIENT_AK
         The AK name used in client subscription
     """
+    env.disable_known_hosts = True
     if check_necessary_env_variables_for_upgrade(product):
         from_version = os.environ.get('FROM_VERSION')
         to_version = os.environ.get('TO_VERSION')


### PR DESCRIPTION
- Every time before triggering job for upgrade we need to remove ssh key from jenkins node while using setup_products_for_upgrade and product_upgrade tasks. Now no need to remove keys manually.

- Added task for satellite-clone installation which will be used in customer db upgrade automation.


