### PR TITLE
Puppet upgrade intialization fix

### DIFF
--- a/upgrade/client.py
+++ b/upgrade/client.py
@@ -39,6 +39,7 @@ def satellite6_client_setup():
     # If User Defined Clients Hostname provided
     clients6 = os.environ.get('CLIENT6_HOSTS')
     clients7 = os.environ.get('CLIENT7_HOSTS')
+    puppet_clients7 = None
     docker_vm = os.environ.get('DOCKER_VM')
     clients_count = os.environ.get('CLIENTS_COUNT')
     from_version = os.environ.get('FROM_VERSION')

--- a/upgrade/helpers/tools.py
+++ b/upgrade/helpers/tools.py
@@ -227,7 +227,7 @@ def create_setup_dict(setups_dict):
     """Creates a file to save the return values from setup_products_for_upgrade
      task
 
-    :param string setups_dict: Dictionary of all return value of
+    :param dict setups_dict: Dictionary of all return value of
     setup_products_for_upgrade
     """
     with open('product_setup', 'wb') as pref:

--- a/upgrade/runner.py
+++ b/upgrade/runner.py
@@ -50,7 +50,7 @@ def setup_products_for_upgrade(product, os_version):
         e.g: rhel6, rhel7
     """
     if check_necessary_env_variables_for_upgrade(product):
-        sat_host = cap_hosts = clients6 = clients7 = None
+        sat_host = cap_hosts = clients6 = clients7 = puppet_clients7 = None
         logger.info('Setting up Satellite ....')
         sat_host = satellite6_setup(os_version)
         if product == 'capsule' or product == 'n-1' or product == 'longrun':
@@ -225,6 +225,10 @@ def product_upgrade(product):
                                     foreman_debug,
                                     'capsule_{}'.format(cap_host),
                                     host=cap_host)
+                            # Execute tasks as post upgrade tier1 tests
+                            # are dependent
+                            if product == 'longrun':
+                                post_upgrade_test_tasks(sat_host, cap_host)
                         except Exception:
                             # Generate foreman debug on failed capsule upgrade
                             execute(
@@ -239,10 +243,6 @@ def product_upgrade(product):
                     satellite6_client_upgrade('rhel7', clients7)
                     satellite6_client_upgrade(
                         'rhel7', puppet_clients7, puppet=True)
-                if product == 'longrun':
-                    # Execute tasks as post upgrade tier1 tests
-                    # are dependent
-                    post_upgrade_test_tasks(sat_host, cap_host)
         except Exception:
             # Generate foreman debug on failed satellite upgrade
             execute(foreman_debug, 'satellite_{}'.format(sat_host),


### PR DESCRIPTION
This Fixes:
1. Puppet Upgrade clients initialization to None
2. Post upgrade tier task place was incorrect so corrected
3. Docstring data type fix