### PR TITLE
Fix generate_docker_clients def to return either katello or puppet clients

### DIFF
--- a/upgrade/client.py
+++ b/upgrade/client.py
@@ -93,13 +93,13 @@ def satellite6_client_setup():
             'rhel6',
             int(clients_count)/2,
             host=docker_vm
-        )[docker_vm]['katello']
+        )[docker_vm]
         clients7 = execute(
             generate_satellite_docker_clients_on_rhevm,
             'rhel7',
             int(clients_count)/2,
             host=docker_vm
-        )[docker_vm]['katello']
+        )[docker_vm]
         # Allow all puppet clients to be signed automatically
         execute(
             lambda: run('echo "*" > /etc/puppetlabs/puppet/autosign.conf'),
@@ -108,7 +108,7 @@ def satellite6_client_setup():
             generate_satellite_docker_clients_on_rhevm, 'rhel7', 2,
             puppet=True,
             host=docker_vm
-        )[docker_vm]['puppet']
+        )[docker_vm]
         # Sync latest sat tools repo to clients if downstream
         if all([
             os.environ.get('TOOLS_URL_RHEL6'),

--- a/upgrade/helpers/docker.py
+++ b/upgrade/helpers/docker.py
@@ -15,7 +15,7 @@ def generate_satellite_docker_clients_on_rhevm(
         custom_ak=None,
         org_label=None,
         puppet=False):
-    """Generates satellite clients on docker as containers
+    """Generates satellite katello or puppet clients on docker as containers
 
     :param string client_os: Client OS of which client to be generated
         e.g: rhel6, rhel7
@@ -24,6 +24,8 @@ def generate_satellite_docker_clients_on_rhevm(
     :param string org_label: The organization in which the docker clients to
         created and where the custom ak is available
     :param bool puppet: Genearates puppet clients only if true
+    :return dict: Returns the dictionary of katello or puppet clients
+        By default katello clients will be created
 
     Environment Variables:
 
@@ -40,7 +42,7 @@ def generate_satellite_docker_clients_on_rhevm(
     satellite_hostname = os.environ.get('RHEV_SAT_HOST')
     ak = custom_ak or os.environ.get(
         'RHEV_CLIENT_AK_{}'.format(client_os.upper()))
-    result = {'katello': {}, 'puppet': {}}
+    result = {}
     puppet = bool(puppet)
     if not puppet:
         host_title = 'scenariokatelloclient{0}'.format(
@@ -67,7 +69,7 @@ def generate_satellite_docker_clients_on_rhevm(
                 '-e "SATHOST={1}" -e "AK={2}" {3}'.format(
                     hostname, satellite_hostname, ak, image.format(client_os))
         container_id = run(create_command)
-        result['puppet' if puppet else 'katello'][hostname] = container_id
+        result[hostname] = container_id
     return result
 
 

--- a/upgrade_tests/helpers/scenarios.py
+++ b/upgrade_tests/helpers/scenarios.py
@@ -114,7 +114,7 @@ def dockerize(ak_name=None, distro=None, org_label=None):
             wait_till_rhevm4_instance_status(instance_name, 'up', 5)
             execute(manage_daemon, 'restart', 'docker', host=docker_vm)
     time.sleep(5)
-    logger.info('Generating client on RHEL7 on Docker. '
+    logger.info('Generating katello client on RHEL7 on Docker. '
                 'Please wait .....')
     # Generate Clients on RHEL 7
     time.sleep(30)


### PR DESCRIPTION
This will fix the upgrade scenarios getting failed.
