### PR TITLE
Puppet Autoconf setting as per sat version

### DIFF
--- a/upgrade/client.py
+++ b/upgrade/client.py
@@ -16,6 +16,7 @@ from upgrade.helpers.rhevm4 import (
     wait_till_rhevm4_instance_status
 )
 from upgrade.helpers.tasks import (
+    puppet_autosign_hosts,
     sync_tools_repos_to_upgrade
 )
 from upgrade.helpers.tools import version_filter
@@ -102,8 +103,7 @@ def satellite6_client_setup():
         )[docker_vm]
         # Allow all puppet clients to be signed automatically
         execute(
-            lambda: run('echo "*" > /etc/puppetlabs/puppet/autosign.conf'),
-            host=sat_host)
+            puppet_autosign_hosts, from_version, ['*'], host=sat_host)
         puppet_clients7 = execute(
             generate_satellite_docker_clients_on_rhevm, 'rhel7', 2,
             puppet=True,
@@ -152,8 +152,7 @@ def satellite6_client_setup():
             host=docker_vm)
         # Resetting autosign conf
         execute(
-            lambda: run('echo "" > /etc/puppetlabs/puppet/autosign.conf'),
-            host=sat_host)
+            puppet_autosign_hosts, from_version, [''], False, host=sat_host)
     logger.info('Clients are ready for Upgrade.')
     return clients6, clients7, puppet_clients7
 

--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -711,3 +711,19 @@ def setup_satellite_clone():
     run('yum repolist')
     # install foreman-maintain
     run('yum install satellite-clone -y')
+
+
+def puppet_autosign_hosts(version, hosts, append=True):
+    """Appends host entries to puppet autosign conf file
+
+    :param str version: The current satellite version
+    :param list hosts: The list of hosts to be added for autoconf
+    :param bool append: Whether to add or append
+    """
+    append = '>>' if append else '>'
+    puppetver = 'ver1' if version in ['6.1', '6.2'] else 'ver2'
+    puppetfile = {
+        'ver1': '/etc/puppet/autosign.conf',
+        'ver2': '/etc/puppetlabs/puppet/autosign.conf'}
+    for host in hosts:
+        run('echo "{0}" {1} {2}'.format(host, append, puppetfile[puppetver]))


### PR DESCRIPTION
This fixes the issue of puppet autoconf.  

**We are not limiting the puppet client to 6.4 only, but supporting all sat vers :)**

Fixes #199 