### PR TITLE
Fix No Capsule failing upgrade with preupgrade checks

### DIFF
--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -785,5 +785,6 @@ def pre_upgrade_system_checks(capsules):
     :param capsules: The list of capsules
     """
     # Check and wait if the capsule sync task is running before upgrade
-    for capsule in capsules:
-        wait_untill_capsule_sync(capsule)
+    if capsules:
+        for capsule in capsules:
+            wait_untill_capsule_sync(capsule)


### PR DESCRIPTION
Fixes issue:

```
    INFO:upgrade_logging:Performing UPGRADE FROM 6.3 TO 6.4
    Traceback (most recent call last):
      File "/home/jenkins/shiningpanda/jobs/8764b415/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/main.py", line 763, in main
        *args, **kwargs
      File "/home/jenkins/shiningpanda/jobs/8764b415/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/tasks.py", line 427, in execute
        results['<local-only>'] = task.run(*args, **new_kwargs)
      File "/home/jenkins/shiningpanda/jobs/8764b415/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/tasks.py", line 174, in run
        return self.wrapped(*args, **kwargs)
      File "/home/jenkins/workspace/satellite6-upgrader/upgrade/runner.py", line 172, in product_upgrade
        pre_upgrade_system_checks(cap_hosts)
      File "/home/jenkins/workspace/satellite6-upgrader/upgrade/helpers/tasks.py", line 788, in pre_upgrade_system_checks
        for capsule in capsules:
    TypeError: 'NoneType' object is not iterable
```