### PR TITLE
Fix and improve existence for 6.4

### DIFF
--- a/upgrade_tests/helpers/common.py
+++ b/upgrade_tests/helpers/common.py
@@ -65,22 +65,22 @@ def existence(pre, post, component=None):
         return pre == post
 
 
-def run_to_upgrade(version):
-    """Decorator on test definition to run that test on given 'version' only.
+def dont_run_to_upgrade(versions):
+    """Decorator on test definition to not to run that test on given 'versions'
 
     Usage:
 
-    * If version is '6.1', then the test will run while upgrading from 6.1 only
-    * If version is '6.2', then the test will run while upgrading from 6.2 only
+    * If '6.1' in versions, then the test will not run while upgrading from 6.1
+    * If '6.2'in versions, then the test will not run while upgrading from 6.2
     * If this decorator is not called on test def, then the test will run on
         all versions
 
     Example:
 
-        Following test will run only when upgrading from 6.2,
+        Following test will not run when upgrading from 6.2,
         in short when FROM_VERSION = 6.2
 
-        @run_to_upgrade('6.2')
+        @dont_run_to_upgrade('6.2')
         def test_something():
             # Do test related things
 
@@ -89,18 +89,19 @@ def run_to_upgrade(version):
     FROM_VERSION
         Current satellite version which will be upgraded to next version
 
-    :param str version: The satellite version only on which the test will run
-    :return: If the version and FROM_VERSION doesnt matches then
-        pytests skip test
+    :param str/list versions: The sat versions onto which the test wont run
+    :return: If FROM_VERSION is in versions then pytests skips test
     """
     allowed_versions = ('6.0', '6.1', '6.2', '6.3', '6.4')
-    if version not in allowed_versions:
-        raise VersionException(
-            'Wrong sat version provided to run this test. Provide one of '
-            '{}'.format(allowed_versions))
     if cur_ver not in allowed_versions:
         raise VersionException(
             'Wrong sat version provided in FROM VERSION env var. Provide one '
             'of {}'.format(allowed_versions))
+    versions = [versions] if type(versions) is str else versions
+    for version in versions:
+        if version not in allowed_versions:
+            raise VersionException(
+                'Wrong sat version provided to run this test. Provide one of '
+                '{}'.format(allowed_versions))
     return pytest.mark.skipif(
-        version != cur_ver, reason='Not for version {}'.format(cur_ver))
+        cur_ver in versions, reason='Not for version {}'.format(cur_ver))

--- a/upgrade_tests/helpers/constants.py
+++ b/upgrade_tests/helpers/constants.py
@@ -66,7 +66,8 @@ class cli_const:
             'content-host',
             'compute-resource',
             'discovery',
-            'discovery_rule',
+            'discovery-rule' if to_version in [
+                '6.3', '6.4'] else 'discovery_rule',
             'domain',
             'environment',
             'filter',

--- a/upgrade_tests/helpers/variants.py
+++ b/upgrade_tests/helpers/variants.py
@@ -21,108 +21,136 @@ class VersionError(Exception):
 #
 # Note: The variants should be listed from 6.1 onwards
 _entity_varients = {
+    'capsule': [
+        ['tftp, dns, dhcp, puppet, puppet ca, bmc, pulp node, templates, discovery, openscap, dynflow, ssh']*3 + # noqa
+        ['puppet, puppet ca, pulp node, templates, discovery, tftp, dns, dhcp, bmc, openscap, dynflow, ssh, ansible'], # noqa
+        ['tftp, dns, dhcp, puppet, puppet ca, bmc, pulp, discovery, openscap, dynflow, ssh']*3 + # noqa
+        ['tftp, dns, dhcp, puppet, puppet ca, pulp, discovery, bmc, openscap, dynflow, ssh, ansible'] # noqa
+    ],
     'compute-resource': [
-        ['rhev', 'rhev', 'rhv']],
+        ['rhev']*2+['rhv']*2],
     'filter': [
         # Resource Type Variants
-        ['lookupkey', 'variablelookupkey', 'variablelookupkey'],
-        ['(miscellaneous)', 'foremanopenscap::arfreport',
-         'foremanopenscap::arfreport'],
-        ['organization', 'katello::subscription', 'katello::subscription'],
-        ['configtemplate', 'provisioningtemplate', 'provisioningtemplate'],
+        ['lookupkey']+['variablelookupkey']*3,
+        ['(miscellaneous)']+['foremanopenscap::arfreport']*3,
+        ['organization']+['katello::subscription']*3,
+        ['configtemplate']+['provisioningtemplate']*3,
+        ['authsourceldap']*3+['authsource'],
+        ['templateinvocation']*3+['(miscellaneous)'],
+        ['docker/imagesearch']*3+['(miscellaneous)'],
         # Permissions Variants
         ['view_templates, create_templates, edit_templates, '
-         'destroy_templates, deploy_templates',
-         'view_provisioning_templates, create_provisioning_templates, '
+         'destroy_templates, deploy_templates'] +
+        ['view_provisioning_templates, create_provisioning_templates, '
          'edit_provisioning_templates, destroy_provisioning_templates, '
-         'deploy_provisioning_templates',
-         'view_provisioning_templates, create_provisioning_templates, '
-         'edit_provisioning_templates, destroy_provisioning_templates, '
-         'deploy_provisioning_templates'],
-        ['viewer', 'viewer', 'customized viewer'],
-        ['site manager', 'site manager', 'customized site manager'],
-        ['manager', 'manager', 'customized manager'],
-        ['discovery reader', 'discovery reader', 'customized discovery reader'], # noqa
-        ['discovery manager', 'discovery manager', 'customized discovery manager'], # noqa
-        ['compliance viewer', 'compliance viewer', 'customized compliance viewer'], # noqa
-        ['compliance manager', 'compliance manager', 'customized compliance manager'], # noqa
-        ['anonymous', 'anonymous', 'default role'],
-        ['commonparameter', 'commonparameter', 'parameter']],
+         'deploy_provisioning_templates']*3,
+        ['viewer']*2+['customized viewer']*2,
+        ['site manager']*2+['customized site manager']*2,
+        ['manager']*2+['customized manager']*2,
+        ['discovery reader']*2+['customized discovery reader']*2,
+        ['discovery manager']*2+['customized discovery manager']*2,
+        ['compliance viewer']*2+['customized compliance viewer']*2,
+        ['compliance manager']*2+['customized compliance manager']*2,
+        ['anonymous']*2+['default role']*2,
+        ['commonparameter']*2+['parameter']*2,
+        ['execute_template_invocation']*3+[''],
+        ['create_job_invocations, view_job_invocations']*3 +
+        ['create_job_invocations, view_job_invocations, cancel_job_invocations'], # noqa
+        ['execute_template_invocation, filter_autocompletion_for_template_invocation']*3 + # noqa
+        ['filter_autocompletion_for_template_invocation, create_template_invocations'], # noqa
+        ['view_hostgroups, create_hostgroups, edit_hostgroups, destroy_hostgroups']*3 + # noqa
+        ['view_hostgroups, create_hostgroups, edit_hostgroups, destroy_hostgroups, play_roles_on_hostgroup'], # noqa
+        ['view_registries, create_registries, destroy_registries']*3 +
+        ['view_registries, create_registries, destroy_registries, search_repository_image_search'], # noqa
+        ['search_repository_image_search']*3 + [''],
+        ['view_gpg_keys, create_gpg_keys, edit_gpg_keys, destroy_gpg_keys']*3 +
+        ['view_gpg_keys, create_gpg_keys, edit_gpg_keys, destroy_gpg_keys, view_content_credentials, create_content_credentials, edit_content_credentials, destroy_content_credentials'], # noqa
+        ['view_subscriptions, attach_subscriptions, unattach_subscriptions, import_manifest, delete_manifest']*3 + # noqa
+        ['view_subscriptions, attach_subscriptions, unattach_subscriptions, import_manifest, delete_manifest, manage_subscription_allocations'], # noqa
+        ['execute_template_invocation, filter_autocompletion_for_template_invocation']*3 + # noqa
+        ['filter_autocompletion_for_template_invocation, create_template_invocations, view_template_invocations'], # noqa
+        ['view_gpg_keys']*3 + ['view_gpg_keys, view_content_credentials'],
+        ['view_hosts, create_hosts, build_hosts, view_discovered_hosts, provision_discovered_hosts, edit_discovered_hosts, destroy_discovered_hosts, submit_discovered_hosts, auto_provision_discovered_hosts']*3 + # noqa
+        ['view_hosts, create_hosts, edit_hosts, build_hosts, view_discovered_hosts, provision_discovered_hosts, edit_discovered_hosts, destroy_discovered_hosts, submit_discovered_hosts, auto_provision_discovered_hosts'], # noqa
+        ['view_hosts, create_hosts, edit_hosts, destroy_hosts, build_hosts, power_hosts, console_hosts, puppetrun_hosts, ipmi_boot_hosts, view_discovered_hosts, provision_discovered_hosts, edit_discovered_hosts, destroy_discovered_hosts, submit_discovered_hosts, auto_provision_discovered_hosts']*3 + # noqa
+        ['view_hosts, create_hosts, edit_hosts, destroy_hosts, build_hosts, power_hosts, console_hosts, puppetrun_hosts, ipmi_boot_hosts, view_discovered_hosts, provision_discovered_hosts, edit_discovered_hosts, destroy_discovered_hosts, submit_discovered_hosts, auto_provision_discovered_hosts, play_roles_on_host'] # noqa
+    ],
     'organization': [
-        ['default_organization', 'default_organization', 'default organization']], # noqa
+        ['default_organization']*3+['default organization']], # noqa
     'role': [
         # Role Variants
-        ['viewer', 'viewer', 'customized viewer'],
-        ['site manager', 'site manager', 'customized site manager'],
-        ['manager', 'manager', 'customized manager'],
-        ['discovery reader', 'discovery reader', 'customized discovery reader'], # noqa
-        ['discovery manager', 'discovery manager', 'customized discovery manager'], # noqa
-        ['compliance viewer', 'compliance viewer', 'customized compliance viewer'], # noqa
-        ['compliance manager', 'compliance manager', 'customized compliance manager'], # noqa
-        ['anonymous', 'anonymous', 'default role']],
+        ['viewer']*2+['customized viewer']*2,
+        ['site manager']*2+['customized site manager']*2,
+        ['manager']*2+['customized manager']*2,
+        ['discovery reader']*2+['customized discovery reader']*2, # noqa
+        ['discovery manager']*2+['customized discovery manager']*2, # noqa
+        ['compliance viewer']*2+['customized compliance viewer']*2, # noqa
+        ['compliance manager']*2+['customized compliance manager']*2, # noqa
+        ['anonymous']*2+['default role']*2],
     'settings': [
         # Value Variants
-        ['immediate', 'immediate', 'on_demand'],
-        ['', '', '/etc/pki/katello/certs/katello-apache.crt'],
-        ['', '', '/etc/pki/katello/private/katello-apache.key'],
-        ['false', 'false', 'true'],
-        ['["lo", "usb*", "vnet*", "macvtap*"]',
-         '["lo", "usb*", "vnet*", "macvtap*"]',
-         '["lo", "usb*", "vnet*", "macvtap*", "_vdsmdummy_", "veth*", '
+        ['immediate']*2+['on_demand']*2,
+        ['']*2+['/etc/pki/katello/certs/katello-apache.crt']*2,
+        ['']*2+['/etc/pki/katello/private/katello-apache.key']*2,
+        ['false']*2+['true']*2,
+        ['["lo", "usb*", "vnet*", "macvtap*"]']*2 +
+        ['["lo", "usb*", "vnet*", "macvtap*", "_vdsmdummy_", "veth*", '
          '"docker*", "tap*", "qbr*", "qvb*", "qvo*", "qr-*", "qg-*", '
-         '"vlinuxbr*", "vovsbr*"]'],
+         '"vlinuxbr*", "vovsbr*"]']*2,
         # Description Variants
-        ['fact name to use for primary interface detection and hostname',
-         'fact name to use for primary interface detection and hostname',
-         'fact name to use for primary interface detection'],
-        ['automatically reboot discovered host during provisioning',
-         'automatically reboot discovered host during provisioning',
-         'automatically reboot or kexec discovered host during provisioning'],
-        ['default provisioning template for new atomic operating systems',
-         'default provisioning template for new atomic operating systems',
-         'default provisioning template for new atomic operating systems '
-         'created from synced content'],
-        ['default finish template for new operating systems',
-         'default finish template for new operating systems',
-         'default finish template for new operating systems created '
-         'from synced content'],
-        ['default ipxe template for new operating systems',
-         'default ipxe template for new operating systems',
-         'default ipxe template for new operating systems created from '
-         'synced content'],
-        ['default kexec template for new operating systems',
-         'default kexec template for new operating systems',
-         'default kexec template for new operating systems created '
-         'from synced content'],
-        ['default provisioning template for new operating systems',
-         'default provisioning template for new operating systems',
-         'default provisioning template for operating systems created'
-         ' from synced content'],
-        ['default partitioning table for new operating systems',
-         'default partitioning table for new operating systems',
-         'default partitioning table for new operating systems created'
-         ' from synced content'],
-        ['default pxelinux template for new operating systems',
-         'default pxelinux template for new operating systems',
-         'default pxelinux template for new operating systems created'
-         ' from synced content'],
-        ['default user data for new operating systems',
-         'default user data for new operating systems',
-         'default user data for new operating systems created from '
-         'synced content'],
+        ['fact name to use for primary interface detection and hostname']*2 +
+         ['fact name to use for primary interface detection']*2,
+        ['automatically reboot discovered host during provisioning']*2 +
+         ['automatically reboot or kexec discovered host during provisioning']*2, # noqa
+        ['default provisioning template for new atomic operating systems']*2 +
+         ['default provisioning template for new atomic operating systems '
+         'created from synced content']*2,
+        ['default finish template for new operating systems']*2 +
+         ['default finish template for new operating systems created '
+         'from synced content']*2,
+        ['default ipxe template for new operating systems']*2 +
+         ['default ipxe template for new operating systems created from '
+         'synced content']*2,
+        ['default kexec template for new operating systems']*2 +
+         ['default kexec template for new operating systems created '
+         'from synced content']*2,
+        ['default provisioning template for new operating systems']*2 +
+         ['default provisioning template for operating systems created'
+         ' from synced content']*2,
+        ['default partitioning table for new operating systems']*2 +
+         ['default partitioning table for new operating systems created'
+         ' from synced content']*2,
+        ['default pxelinux template for new operating systems']*2 +
+         ['default pxelinux template for new operating systems created'
+         ' from synced content']*2,
+        ['default user data for new operating systems']*2 +
+         ['default user data for new operating systems created from '
+         'synced content']*2,
         ['when unregistering host via subscription-manager, also delete '
-         'server-side host record',
-         'when unregistering host via subscription-manager, also delete'
-         ' server-side host record',
-         'when unregistering a host via subscription-manager, also delete'
+         'server-side host record']*2 +
+         ['when unregistering a host via subscription-manager, also delete'
          ' the host record. managed resources linked to host such as virtual'
-         ' machines and dns records may also be deleted.'],
-        ['private key that foreman will use to encrypt websockets',
-         'private key that foreman will use to encrypt websockets',
-         'private key file that foreman will use to encrypt websockets']],
+         ' machines and dns records may also be deleted.']*2,
+        ['private key that foreman will use to encrypt websockets']*2 +
+         ['private key file that foreman will use to encrypt websockets']*2,
+        ['duration in minutes after the puppet interval for servers to be classed as out of sync.']*3 + # noqa
+         ['duration in minutes after servers are classed as out of sync.'],
+        ['satellite kickstart default user data'] * 3 + ['kickstart default user data'], # noqa
+        ['satellite kickstart default'] * 3 + ['kickstart default'],
+        ['satellite kickstart default finish'] * 3 + ['kickstart default finish'], # noqa
+        ['satellite atomic kickstart default'] * 3 + ['atomic kickstart default'], # noqa
+        ['default_location'] * 3 + ['default location']],
     'subscription': [
         # Validity Variants
-        ['-1', '-1', 'unlimited']],
+        ['-1']*2+['unlimited']*2],
+    'template': [
+        # name variants
+        ['idm_register']*3+['deprecated idm_register'],
+        ['satellite atomic kickstart default']*3+['deprecated satellite atomic kickstart default'], # noqa
+        ['satellite kickstart default']*3+['deprecated satellite kickstart default'], # noqa
+        ['satellite kickstart default finish']*3+['deprecated satellite kickstart default finish'], # noqa
+        ['satellite kickstart default user data']*3+['deprecated satellite kickstart default user data'] # noqa
+    ]
 }
 
 

--- a/upgrade_tests/test_existance_relations/api/test_domains.py
+++ b/upgrade_tests/test_existance_relations/api/test_domains.py
@@ -16,6 +16,7 @@
 
 :Upstream: No
 """
+import os
 import pytest
 from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
@@ -34,4 +35,7 @@ def test_positive_domains_by_subnet(pre, post):
 
     :expectedresults: Subnets of all domains should be retained post upgrade
     """
+    if os.environ.get('TO_VERSION') == '6.4':
+        if post:
+            [subnet.pop('description') for subnet in post]
     assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_activationkeys.py
+++ b/upgrade_tests/test_existance_relations/cli/test_activationkeys.py
@@ -28,7 +28,7 @@ aks_cv = compare_postupgrade(component, 'content view')
 aks_lc = compare_postupgrade(component, 'lifecycle environment')
 aks_name = compare_postupgrade(component, 'name')
 aks_hl = compare_postupgrade(
-    component, ('consumed', 'host limit', 'host limit'))
+    component, ('consumed', 'host limit', 'host limit', 'host limit'))
 
 
 # Tests

--- a/upgrade_tests/test_existance_relations/cli/test_capsules.py
+++ b/upgrade_tests/test_existance_relations/cli/test_capsules.py
@@ -18,7 +18,7 @@ associations post upgrade
 :Upstream: No
 """
 import pytest
-from upgrade_tests.helpers.common import run_to_upgrade, existence
+from upgrade_tests.helpers.common import dont_run_to_upgrade, existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -29,7 +29,7 @@ cap_url = compare_postupgrade(component, 'url')
 
 
 # Tests
-@run_to_upgrade('6.2')
+@dont_run_to_upgrade('6.1')
 @pytest.mark.parametrize(
     "pre,post", cap_features, ids=pytest_ids(cap_features))
 def test_positive_capsules_by_features(pre, post):
@@ -40,7 +40,7 @@ def test_positive_capsules_by_features(pre, post):
     :expectedresults: All features of all capsules should be retained post
         upgrade
     """
-    assert existence(pre, post)
+    assert existence(pre, post, component)
 
 
 @pytest.mark.parametrize("pre,post", cap_name, ids=pytest_ids(cap_name))

--- a/upgrade_tests/test_existance_relations/cli/test_contenthosts.py
+++ b/upgrade_tests/test_existance_relations/cli/test_contenthosts.py
@@ -18,7 +18,7 @@ post upgrade
 :Upstream: No
 """
 import pytest
-from upgrade_tests.helpers.common import existence
+from upgrade_tests.helpers.common import dont_run_to_upgrade, existence
 from robozilla.decorators import pytest_skip_if_bug_open
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
@@ -29,6 +29,7 @@ ch_errata = compare_postupgrade(component, 'installable errata')
 
 
 # Tests
+@dont_run_to_upgrade('6.3')
 @pytest.mark.parametrize("pre,post", ch_name, ids=pytest_ids(ch_name))
 def test_positive_contenthosts_by_name(pre, post):
     """Test all content hosts are existing after upgrade by names
@@ -41,6 +42,7 @@ def test_positive_contenthosts_by_name(pre, post):
     assert existence(pre, post)
 
 
+@dont_run_to_upgrade('6.3')
 @pytest_skip_if_bug_open('bugzilla', 1461397)
 @pytest.mark.parametrize("pre,post", ch_errata, ids=pytest_ids(ch_errata))
 def test_positive_installable_erratas_by_name(pre, post):

--- a/upgrade_tests/test_existance_relations/cli/test_contentviews.py
+++ b/upgrade_tests/test_existance_relations/cli/test_contentviews.py
@@ -20,7 +20,7 @@ associations post upgrade
 import pytest
 
 from robozilla.decorators import pytest_skip_if_bug_open
-from upgrade_tests.helpers.common import existence, run_to_upgrade
+from upgrade_tests.helpers.common import existence, dont_run_to_upgrade
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -60,7 +60,7 @@ def test_positive_cvs_by_label(pre, post):
     assert existence(pre, post)
 
 
-@run_to_upgrade('6.2')
+@dont_run_to_upgrade('6.1')
 @pytest.mark.parametrize(
     "pre,post", cvs_composite, ids=pytest_ids(cvs_composite))
 def test_positive_cvs_by_composite_views(pre, post):

--- a/upgrade_tests/test_existance_relations/cli/test_discovery.py
+++ b/upgrade_tests/test_existance_relations/cli/test_discovery.py
@@ -115,6 +115,6 @@ def test_positive_discovery_by_subnet(pre, post):
     :expectedresults: All discovered hosts subnet should be retained post
         upgrade
     """
-    post = post.split(' (')[0] if to_version == '6.3' else post
-    pre = post.split(' (')[0] if from_version == '6.3' else pre
+    post = post.split(' (')[0] if to_version in ['6.3', '6.4'] else post
+    pre = post.split(' (')[0] if from_version in ['6.3', '6.4'] else pre
     assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_discoveryrulels.py
+++ b/upgrade_tests/test_existance_relations/cli/test_discoveryrulels.py
@@ -17,12 +17,16 @@ its associations post upgrade
 
 :Upstream: No
 """
+import os
 import pytest
 from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
-component = 'discovery_rule'
+if os.environ.get('TO_VERSION') in ['6.3', '6.4']:
+    component = 'discovery-rule'
+else:
+    component = 'discovery_rule'
 drule_name = compare_postupgrade(component, 'name')
 drule_prio = compare_postupgrade(component, 'priority')
 drule_search = compare_postupgrade(component, 'search')

--- a/upgrade_tests/test_existance_relations/cli/test_hostgroups.py
+++ b/upgrade_tests/test_existance_relations/cli/test_hostgroups.py
@@ -25,7 +25,9 @@ from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 component = 'hostgroup'
 hg_name = compare_postupgrade(component, 'name')
 hg_os = compare_postupgrade(component, 'operating system')
-hg_lc = compare_postupgrade(component, 'environment')
+hg_lc = compare_postupgrade(
+    component,
+    ('environment', 'environment', 'environment', 'puppet environment'))
 
 
 # Tests

--- a/upgrade_tests/test_existance_relations/cli/test_scparams.py
+++ b/upgrade_tests/test_existance_relations/cli/test_scparams.py
@@ -18,7 +18,7 @@
 :Upstream: No
 """
 import pytest
-from upgrade_tests.helpers.common import run_to_upgrade, existence
+from upgrade_tests.helpers.common import dont_run_to_upgrade, existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 
@@ -67,7 +67,7 @@ def test_positive_smart_params_by_override(pre, post):
     assert existence(pre, post)
 
 
-@run_to_upgrade('6.2')
+@dont_run_to_upgrade('6.1')
 @pytest.mark.parametrize("pre,post", scp_pclass, ids=pytest_ids(scp_pclass))
 def test_positive_smart_params_by_puppet_class(pre, post):
     """Test all smart parameters associations with its puppet class is retained

--- a/upgrade_tests/test_existance_relations/cli/test_settings.py
+++ b/upgrade_tests/test_existance_relations/cli/test_settings.py
@@ -17,7 +17,7 @@
 :Upstream: No
 """
 import pytest
-from upgrade_tests.helpers.common import run_to_upgrade, existence
+from upgrade_tests.helpers.common import dont_run_to_upgrade, existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
@@ -28,7 +28,7 @@ sett_desc = compare_postupgrade(component, 'description')
 
 
 # Tests
-@run_to_upgrade('6.2')
+@dont_run_to_upgrade('6.1')
 @pytest.mark.parametrize("pre,post", sett_name, ids=pytest_ids(sett_name))
 def test_positive_settings_by_name(pre, post):
     """Test all settings are existing post upgrade by their names
@@ -40,7 +40,7 @@ def test_positive_settings_by_name(pre, post):
     assert existence(pre, post)
 
 
-@run_to_upgrade('6.2')
+@dont_run_to_upgrade('6.1')
 @pytest.mark.parametrize("pre,post", sett_value, ids=pytest_ids(sett_value))
 def test_positive_settings_by_value(pre, post):
     """Test all settings value are preserved post upgrade
@@ -52,7 +52,7 @@ def test_positive_settings_by_value(pre, post):
     assert existence(pre, post, component=component)
 
 
-@run_to_upgrade('6.2')
+@dont_run_to_upgrade('6.1')
 @pytest.mark.parametrize("pre,post", sett_desc, ids=pytest_ids(sett_desc))
 def test_positive_settings_by_description(pre, post):
     """Test all settings descriptions are existing post upgrade

--- a/upgrade_tests/test_existance_relations/cli/test_smartvariables.py
+++ b/upgrade_tests/test_existance_relations/cli/test_smartvariables.py
@@ -18,19 +18,20 @@ and associations post upgrade
 :Upstream: No
 """
 import pytest
-from upgrade_tests.helpers.common import existence, run_to_upgrade
+from upgrade_tests.helpers.common import existence, dont_run_to_upgrade
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
 component = 'smart-variable'
-sv_name = compare_postupgrade(component, ('name', 'name', 'variable'))
+sv_name = compare_postupgrade(
+    component, ('name', 'name', 'variable', 'variable'))
 sv_dv = compare_postupgrade(component, 'default value')
 sv_type = compare_postupgrade(component, 'type')
 sv_pclass = compare_postupgrade(component, 'puppet class')
 
 
 # Tests
-@run_to_upgrade('6.2')
+@dont_run_to_upgrade('6.1')
 @pytest.mark.parametrize("pre,post", sv_name, ids=pytest_ids(sv_name))
 def test_positive_smart_variables_by_name(pre, post):
     """Test all smart variables are existing after upgrade by names
@@ -43,7 +44,7 @@ def test_positive_smart_variables_by_name(pre, post):
     assert existence(pre, post)
 
 
-@run_to_upgrade('6.2')
+@dont_run_to_upgrade('6.1')
 @pytest.mark.parametrize("pre,post", sv_dv, ids=pytest_ids(sv_dv))
 def test_positive_smart_variables_by_default_value(pre, post):
     """Test all smart variables default values are retained after upgrade
@@ -56,7 +57,7 @@ def test_positive_smart_variables_by_default_value(pre, post):
     assert existence(pre, post)
 
 
-@run_to_upgrade('6.2')
+@dont_run_to_upgrade('6.1')
 @pytest.mark.parametrize("pre,post", sv_type, ids=pytest_ids(sv_type))
 def test_positive_smart_variables_by_type(pre, post):
     """Test all smart variables override check is retained after upgrade
@@ -69,7 +70,7 @@ def test_positive_smart_variables_by_type(pre, post):
     assert existence(pre, post)
 
 
-@run_to_upgrade('6.2')
+@dont_run_to_upgrade('6.1')
 @pytest.mark.parametrize("pre,post", sv_pclass, ids=pytest_ids(sv_pclass))
 def test_positive_smart_variables_by_puppet_class(pre, post):
     """Test all smart variables associations with its puppet class is retained

--- a/upgrade_tests/test_existance_relations/cli/test_subscriptions.py
+++ b/upgrade_tests/test_existance_relations/cli/test_subscriptions.py
@@ -25,7 +25,7 @@ from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 # Required Data
 component = 'subscription'
 sub_name = compare_postupgrade(component, 'name')
-sub_uuid = compare_postupgrade(component, ('id', 'uuid', 'uuid'))
+sub_uuid = compare_postupgrade(component, ('id', 'uuid', 'uuid', 'uuid'))
 sub_support = compare_postupgrade(component, 'support')
 sub_qntity = compare_postupgrade(component, 'quantity')
 sub_consume = compare_postupgrade(component, 'consumed')

--- a/upgrade_tests/test_existance_relations/cli/test_template.py
+++ b/upgrade_tests/test_existance_relations/cli/test_template.py
@@ -35,4 +35,4 @@ def test_positive_templates_by_name(pre, post):
 
     :expectedresults: All templates should be retained post upgrade by names
     """
-    assert existence(pre, post)
+    assert existence(pre, post, component)


### PR DESCRIPTION
This PR:

- Fixes the automation issues for 6.4 (should have been at the start of the 6.4 cycle, we ll take care from 6.5)
- Reduce the skip test count from 1092 to less than 10.
- Improve some helpers as per needs
- New Varients data is added, will be sent to Sat6 list for review if the varients are expected

This is reducing the Failures ```from 208 to 16 ``` for 6.4 and the remaining counts needs to reviewed from Dev to accept. If those failures/varients are expected, the count should be almost 0.