### PR TITLE
Remove python-nova as we don't use it anymore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'ovirt-engine-sdk-python==4.2.7',
         'pycurl',
         'python-bugzilla==1.2.2',
-        'python-novaclient',
         'requests',
         'robozilla',
         'shade'


### PR DESCRIPTION
This conflicts with the requirement of robottelo which uses a older version of python-nova and we don't have the requirement of python nova in upgrade anymore.