### PR TITLE
Pinned pytest to 3.6.1 and flake8 fixes

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,4 +1,3 @@
-pytest==3.0.4
 mock==2.0.0
 pytest-cov
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'fauxfactory==2.0.9',
         'ovirt-engine-sdk-python==4.2.7',
         'pycurl',
+        'pytest==3.6.1',
         'python-bugzilla==1.2.2',
         'python-novaclient',
         'requests',

--- a/upgrade/helpers/docker.py
+++ b/upgrade/helpers/docker.py
@@ -104,7 +104,7 @@ def refresh_subscriptions_on_docker_clients(container_ids):
         docker_execute_command(container_ids, 'yum clean all', quiet=True)
 
 
-def docker_execute_command(container_id, command, quiet=True, async=False):
+def docker_execute_command(container_id, command, quiet=True, **kwargs):
     """Executes command on running docker container
 
     :param string container_id: Running containers id to execute command
@@ -119,14 +119,14 @@ def docker_execute_command(container_id, command, quiet=True, async=False):
             'quiet parameter value should be boolean type. '
             '{} type provided.'.format(type(quiet))
         )
-    if not isinstance(async, bool):
+    if 'async' in kwargs and not isinstance(kwargs['async'], bool):
         raise TypeError(
             'async parameter value should be boolean type. '
-            '{} type provided.'.format(type(async))
+            '{} type provided.'.format(type(kwargs['async']))
         )
     return run(
         'docker exec {0} {1} {2}'.format(
-            '-d' if async else '', container_id, command),
+            '-d' if kwargs['async'] else '', container_id, command),
         quiet=quiet
         )
 

--- a/upgrade/helpers/tools.py
+++ b/upgrade/helpers/tools.py
@@ -175,7 +175,7 @@ def version_filter(rpm_name):
 
     :param string rpm_name: The katello-agent rpm name
     """
-    return re.search('\d(\-\d|\.\d)*', rpm_name).group()
+    return re.search(r'\d(\-\d|\.\d)*', rpm_name).group()
 
 
 def _extract_sat_cap_version(command):


### PR DESCRIPTION
Pinning pytest to 3.6.1 also fixes the issues for make lint wrt py3.

Reason:
1. The upgrade scenarios are failing in jenkins due to pytest 3.9 throwing error:

```
/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/bin/py.test -v --continue-on-collection-errors -s -m pre_upgrade --junit-xml=test_scenarios-pre-results.xml -o junit_suite_name=test_scenarios-pre upgrade_tests/test_scenarios/
Traceback (most recent call last):
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/bin/py.test", line 11, in <module>
    sys.exit(main())
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/config.py", line 47, in main
    config = _prepareconfig(args, plugins)
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/config.py", line 132, in _prepareconfig
    pluginmanager=pluginmanager, args=args)
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 745, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 339, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 334, in <lambda>
    _MultiCall(methods, kwargs, hook.spec_opts).execute()
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 613, in execute
    return _wrapped_call(hook_impl.function(*args), self.execute)
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 250, in _wrapped_call
    wrap_controller.send(call_outcome)
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/helpconfig.py", line 32, in pytest_cmdline_parse
    config = outcome.get_result()
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 280, in get_result
    _reraise(*ex)  # noqa
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 265, in __init__
    self.result = func()
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 614, in execute
    res = hook_impl.function(*args)
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/config.py", line 882, in pytest_cmdline_parse
    self.parse(args)
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/config.py", line 1045, in parse
    args = self.getini('testpaths')
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/config.py", line 1066, in getini
    self._inicache[name] = val = self._getini(name)
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/config.py", line 1074, in _getini
    value = self._get_override_ini_value(name)
  File "/home/jenkins/shiningpanda/jobs/87fc9fc8/virtualenvs/d41d8cd9/lib/python2.7/site-packages/_pytest/config.py", line 1123, in _get_override_ini_value
    (key, user_ini_value) = ini_config.split("=", 1)
ValueError: need more than 1 value to unpack
```
2. The robottelo is also currently pinned to pytest 3.6.1 and as we are going to execute upgrade scenarios from there soon, this should help.

Pinned Untill- 

1.  We test and ensure pytest 3.9 not causing issues
2. Untill we test existence tests with pytest 3.9