### PR TITLE
Fix KeyError async

### DIFF
--- a/upgrade/helpers/docker.py
+++ b/upgrade/helpers/docker.py
@@ -126,7 +126,7 @@ def docker_execute_command(container_id, command, quiet=True, **kwargs):
         )
     return run(
         'docker exec {0} {1} {2}'.format(
-            '-d' if kwargs['async'] else '', container_id, command),
+            '-d' if kwargs.get('async') else '', container_id, command),
         quiet=quiet
         )
 


### PR DESCRIPTION
Fix :
```
 Executing task 'refresh_subscriptions_on_docker_clients'
Traceback (most recent call last):
  File "/home/jenkins/shiningpanda/jobs/564d526e/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/main.py", line 763, in main
    *args, **kwargs
  File "/home/jenkins/shiningpanda/jobs/564d526e/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/tasks.py", line 427, in execute
    results['<local-only>'] = task.run(*args, **new_kwargs)
  File "/home/jenkins/shiningpanda/jobs/564d526e/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/tasks.py", line 174, in run
    return self.wrapped(*args, **kwargs)
  File "/home/jenkins/workspace/upgrade-to-6.4-rhel7/upgrade/runner.py", line 67, in setup_products_for_upgrade
    ) = satellite6_client_setup()
  File "/home/jenkins/workspace/upgrade-to-6.4-rhel7/upgrade/client.py", line 154, in satellite6_client_setup
    host=docker_vm)
  File "/home/jenkins/shiningpanda/jobs/564d526e/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/tasks.py", line 387, in execute
    multiprocessing
  File "/home/jenkins/shiningpanda/jobs/564d526e/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/tasks.py", line 277, in _execute
    return task.run(*args, **kwargs)
  File "/home/jenkins/shiningpanda/jobs/564d526e/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/tasks.py", line 174, in run
    return self.wrapped(*args, **kwargs)
  File "/home/jenkins/workspace/upgrade-to-6.4-rhel7/upgrade/helpers/docker.py", line 100, in refresh_subscriptions_on_docker_clients
    container_id, 'subscription-manager refresh')
  File "/home/jenkins/workspace/upgrade-to-6.4-rhel7/upgrade/helpers/docker.py", line 129, in docker_execute_command
    '-d' if kwargs['async'] else '', container_id, command),
KeyError: 'async'
```