### PR TITLE
Fix Existence Tests for 6.5, reduced to 1 now

### DIFF
--- a/upgrade_tests/helpers/common.py
+++ b/upgrade_tests/helpers/common.py
@@ -61,7 +61,7 @@ def existence(pre, post, component=None):
         return assert_varients(component, pre, post)
     else:
         if isinstance(pre, list) and isinstance(post, list):
-            return sorted(pre) == sorted(post)
+            return sorted(list(pre)) == sorted(list(post))
         return pre == post
 
 

--- a/upgrade_tests/helpers/constants.py
+++ b/upgrade_tests/helpers/constants.py
@@ -21,8 +21,7 @@ class cli_const:
             'capsule',
             'compute-resource',
             'discovery',
-            'discovery-rule' if to_version in [
-                '6.3', '6.4'] else 'discovery_rule',
+            'discovery-rule' if float(to_version) >= 6.3 else 'discovery_rule',
             'domain',
             'environment',
             'filter',

--- a/upgrade_tests/test_existance_relations/cli/test_activationkeys.py
+++ b/upgrade_tests/test_existance_relations/cli/test_activationkeys.py
@@ -28,7 +28,7 @@ aks_cv = compare_postupgrade(component, 'content view')
 aks_lc = compare_postupgrade(component, 'lifecycle environment')
 aks_name = compare_postupgrade(component, 'name')
 aks_hl = compare_postupgrade(
-    component, ('consumed', 'host limit', 'host limit', 'host limit'))
+    component, ('consumed', 'host limit', 'host limit', 'host limit', 'host limit'))
 
 
 # Tests

--- a/upgrade_tests/test_existance_relations/cli/test_contenthosts.py
+++ b/upgrade_tests/test_existance_relations/cli/test_contenthosts.py
@@ -29,7 +29,7 @@ ch_errata = compare_postupgrade(component, 'installable errata')
 
 
 # Tests
-@dont_run_to_upgrade('6.3')
+@dont_run_to_upgrade(['6.3', '6.4'])
 @pytest.mark.parametrize("pre,post", ch_name, ids=pytest_ids(ch_name))
 def test_positive_contenthosts_by_name(pre, post):
     """Test all content hosts are existing after upgrade by names
@@ -42,7 +42,7 @@ def test_positive_contenthosts_by_name(pre, post):
     assert existence(pre, post)
 
 
-@dont_run_to_upgrade('6.3')
+@dont_run_to_upgrade(['6.3', '6.4'])
 @pytest_skip_if_bug_open('bugzilla', 1461397)
 @pytest.mark.parametrize("pre,post", ch_errata, ids=pytest_ids(ch_errata))
 def test_positive_installable_erratas_by_name(pre, post):

--- a/upgrade_tests/test_existance_relations/cli/test_discovery.py
+++ b/upgrade_tests/test_existance_relations/cli/test_discovery.py
@@ -115,6 +115,6 @@ def test_positive_discovery_by_subnet(pre, post):
     :expectedresults: All discovered hosts subnet should be retained post
         upgrade
     """
-    post = post.split(' (')[0] if to_version in ['6.3', '6.4'] else post
-    pre = post.split(' (')[0] if from_version in ['6.3', '6.4'] else pre
+    post = post.split(' (')[0] if float(to_version) >= 6.3 else post
+    pre = post.split(' (')[0] if float(from_version) >= 6.3 else pre
     assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_discoveryrulels.py
+++ b/upgrade_tests/test_existance_relations/cli/test_discoveryrulels.py
@@ -23,7 +23,7 @@ from upgrade_tests.helpers.common import existence
 from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 
 # Required Data
-if os.environ.get('TO_VERSION') in ['6.3', '6.4']:
+if float(os.environ.get('TO_VERSION')) >= 6.3:
     component = 'discovery-rule'
 else:
     component = 'discovery_rule'
@@ -57,6 +57,7 @@ def test_positive_discovery_rules_by_priority(pre, post):
     :expectedresults: All discovery rules priorities should be retained post
         upgrade
     """
+    # The priority changes from 0 to some priority number during 6.3 to 6.4 upgrade only
     if os.environ.get('TO_VERSION') == '6.4' and pre == '0':
         assert not existence(pre, post)
     else:

--- a/upgrade_tests/test_existance_relations/cli/test_hostgroups.py
+++ b/upgrade_tests/test_existance_relations/cli/test_hostgroups.py
@@ -27,7 +27,7 @@ hg_name = compare_postupgrade(component, 'name')
 hg_os = compare_postupgrade(component, 'operating system')
 hg_lc = compare_postupgrade(
     component,
-    ('environment', 'environment', 'environment', 'puppet environment'))
+    ('environment', 'environment', 'environment', 'puppet environment', 'puppet environment'))
 
 
 # Tests

--- a/upgrade_tests/test_existance_relations/cli/test_smartvariables.py
+++ b/upgrade_tests/test_existance_relations/cli/test_smartvariables.py
@@ -24,7 +24,7 @@ from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 # Required Data
 component = 'smart-variable'
 sv_name = compare_postupgrade(
-    component, ('name', 'name', 'variable', 'variable'))
+    component, ('name', 'name', 'variable', 'variable', 'variable'))
 sv_dv = compare_postupgrade(component, 'default value')
 sv_type = compare_postupgrade(component, 'type')
 sv_pclass = compare_postupgrade(component, 'puppet class')

--- a/upgrade_tests/test_existance_relations/cli/test_subnets.py
+++ b/upgrade_tests/test_existance_relations/cli/test_subnets.py
@@ -24,8 +24,10 @@ from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 # Required Data
 component = 'subnet'
 sub_name = compare_postupgrade(component, 'name')
-sub_network = compare_postupgrade(component, 'network')
-sub_mask = compare_postupgrade(component, 'mask')
+sub_network = compare_postupgrade(
+    component, ('network', 'network', 'network', 'network addr', 'network addr'))
+sub_mask = compare_postupgrade(
+    component, ('network', 'network', 'network', 'network mask', 'network mask'))
 
 
 # Tests

--- a/upgrade_tests/test_existance_relations/cli/test_subscriptions.py
+++ b/upgrade_tests/test_existance_relations/cli/test_subscriptions.py
@@ -25,7 +25,7 @@ from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
 # Required Data
 component = 'subscription'
 sub_name = compare_postupgrade(component, 'name')
-sub_uuid = compare_postupgrade(component, ('id', 'uuid', 'uuid', 'uuid'))
+sub_uuid = compare_postupgrade(component, ('id', 'uuid', 'uuid', 'uuid', 'uuid'))
 sub_support = compare_postupgrade(component, 'support')
 sub_qntity = compare_postupgrade(component, 'quantity')
 sub_consume = compare_postupgrade(component, 'consumed')


### PR DESCRIPTION
Satellite 6.5 existence has been fixed from 27 failures to 1 failure(expected) and 4 errors to 0.