### PR TITLE
Revert work around added for BZ1644354

### DIFF
--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -25,7 +25,7 @@ from upgrade.helpers.docker import (
 from upgrade.helpers.logger import logger
 from upgrade.helpers.tools import call_entity_method_with_timeout
 from fabric.api import env, execute, put, run, warn_only
-if sys.version_info[0] is 2:
+if sys.version_info[0] == 2:
     from StringIO import StringIO  # (import-error) pylint:disable=F0401
 else:  # pylint:disable=F0401,E0611
     from io import StringIO

--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -25,7 +25,7 @@ from upgrade.helpers.tasks import (
     setup_foreman_maintain,
     upgrade_using_foreman_maintain
 )
-if sys.version_info[0] is 2:
+if sys.version_info[0] == 2:
     from StringIO import StringIO  # (import-error) pylint:disable=F0401
 else:  # pylint:disable=F0401,E0611
     from io import StringIO

--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -97,8 +97,6 @@ def satellite6_upgrade():
                        'Provide one of 6.1, 6.2, 6.3, 6.4, 6.5')
         sys.exit(1)
     major_ver = distro_info()[1]
-    # remove once BZ 1644354 fixed
-    run("yum erase ant-junit -y")
     if os.environ.get('PERFORM_FOREMAN_MAINTAIN_UPGRADE') == 'true' \
             and os.environ.get('OS') == 'rhel7':
         if base_url is None:
@@ -201,8 +199,6 @@ def satellite6_zstream_upgrade():
         sys.exit(1)
     base_url = os.environ.get('BASE_URL')
     major_ver = distro_info()[1]
-    # remove once BZ 1644354 fixed
-    run("yum erase ant-junit -y")
     if os.environ.get('PERFORM_FOREMAN_MAINTAIN_UPGRADE') == "true" \
             and os.environ.get('OS') == 'rhel7':
         if base_url is None:


### PR DESCRIPTION
Fixes #249 
Also fixes travis error in seperate commit

```
flake8 --max-line-length=99 upgrade upgrade_tests
upgrade/satellite.py:28:4: F632 use ==/!= to compare str, bytes, and int literals
upgrade/helpers/tasks.py:28:4: F632 use ==/!= to compare str, bytes, and int literals
make: *** [lint] Error 1
The command "make lint" exited with 2.
```

Please use squash and merge for merging.