### PR TITLE
added none-type fix check

### DIFF
--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -25,7 +25,7 @@ from upgrade.helpers.docker import (
 from upgrade.helpers.logger import logger
 from upgrade.helpers.tools import call_entity_method_with_timeout
 from fabric.api import env, execute, put, run, warn_only
-if sys.version_info[0] is 2:
+if sys.version_info[0] == 2:
     from StringIO import StringIO  # (import-error) pylint:disable=F0401
 else:  # pylint:disable=F0401,E0611
     from io import StringIO

--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -25,7 +25,7 @@ from upgrade.helpers.tasks import (
     setup_foreman_maintain,
     upgrade_using_foreman_maintain
 )
-if sys.version_info[0] is 2:
+if sys.version_info[0] == 2:
     from StringIO import StringIO  # (import-error) pylint:disable=F0401
 else:  # pylint:disable=F0401,E0611
     from io import StringIO

--- a/upgrade_tests/helpers/constants.py
+++ b/upgrade_tests/helpers/constants.py
@@ -21,7 +21,8 @@ class cli_const:
             'capsule',
             'compute-resource',
             'discovery',
-            'discovery-rule' if float(to_version) >= 6.3 else 'discovery_rule',
+            'discovery-rule' if to_version is not None and float(to_version) >= 6.3
+            else 'discovery_rule',
             'domain',
             'environment',
             'filter',


### PR DESCRIPTION
Fixing error https://github.com/SatelliteQE/satellite6-upgrade/issues/289

```
In [11]: to_version = 6.4

In [12]: 'discovery-rule' if to_version is not None and float(to_version) >= 6.3 else 'discovery_rule'
Out[12]: 'discovery-rule'

In [13]: to_version = None

In [14]: 'discovery-rule' if to_version is not None and float(to_version) >= 6.3 else 'discovery_rule'
Out[14]: 'discovery_rule'

In [15]: to_version = 6.3

In [16]: 'discovery-rule' if to_version is not None and float(to_version) >= 6.3 else 'discovery_rule'
Out[16]: 'discovery-rule'
```
