### PR TITLE
f-m enables 65 GA repos which is not available

### DIFF
--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -14,7 +14,7 @@ from automation_tools import (
     setup_fake_manifest_certificate,
 )
 from automation_tools import setup_foreman_discovery, setup_avahi_discovery
-from automation_tools.repository import enable_repos
+from automation_tools.repository import disable_repos, enable_repos
 from automation_tools.utils import get_discovery_image
 from nailgun import entities
 from robozilla.decorators import bz_bug_is_open
@@ -646,9 +646,18 @@ def upgrade_using_foreman_maintain():
             '--target-version {} '
             '-y'.format(os.environ.get('TO_VERSION') + ".z"))
     else:
-        run('foreman-maintain upgrade run '
-            '--whitelist="disk-performance" '
-            '--target-version {} -y'.format(os.environ.get('TO_VERSION')))
+        if os.environ.get('TO_VERSION') == "6.5":
+            disable_repos('*', silent=True)
+            enable_repos('rhel-7-server-rpms')
+            enable_repos('rhel-server-rhscl-7-rpms')
+            enable_repos('rhel-7-server-ansible-2.6-rpms')
+            run('foreman-maintain upgrade run '
+                '--whitelist="disk-performance, repositories-setup" '
+                '--target-version 6.5 -y')
+        else:
+            run('foreman-maintain upgrade run '
+                '--whitelist="disk-performance" '
+                '--target-version {} -y'.format(os.environ.get('TO_VERSION')))
 
 
 def upgrade_puppet3_to_puppet4():


### PR DESCRIPTION
Foreman-maintain enables 6.5 GA repos which is not now available in CDN. So added workaround.
Will revert once 6.5 is GA.