### PR TITLE
Updated Capsule repository related information in rhel contents

### DIFF
--- a/upgrade/helpers/constants.py
+++ b/upgrade/helpers/constants.py
@@ -25,8 +25,7 @@ rhelcontents = {
     },
     'capsule': {
         'prod': 'Red Hat Satellite Capsule',
-        'repofull': 'Red Hat Satellite Capsule {cap_ver} for RHEL {os_ver} Server RPMs '
-                    '{arch} {os_ver}Server',
+        'repofull': 'Red Hat Satellite Capsule {cap_ver} for RHEL {os_ver} Server RPMs {arch}',
         'repo': 'Red Hat Satellite Capsule {cap_ver} (for RHEL {os_ver} Server) (RPMs)',
         'label': 'rhel-{os_ver}-server-satellite-capsule-{cap_ver}-rpms'
     },

--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -183,7 +183,7 @@ def _sync_capsule_subscription_to_capsule_ak(ak):
         ).search()[0]
         try:
             cap_reposet.enable(
-                data={'basearch': 'x86_64', 'releasever': '7Server', 'organization_id': org.id})
+                data={'basearch': 'x86_64', 'organization_id': org.id})
         except requests.exceptions.HTTPError as exp:
             logger.warn(exp)
         cap_repo = entities.Repository(


### PR DESCRIPTION
Please refer #340
Capsule repo full information is different in both 6.5 and 6.6 branch
in 6.6 branches It has
Red Hat Satellite Capsule {cap_ver} for RHEL {os_ver} Server RPMs {arch} {os_ver}Server
and 6.5 it has 
Red Hat Satellite Capsule {cap_ver} for RHEL {os_ver} Server RPMs {arch}