### PR TITLE
Fix(6.4.z): basearch missing and changed capsule repo name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-    - "2.7"
     - "3.6"
 install:
     - pip install -r requirements.txt

--- a/upgrade/helpers/constants.py
+++ b/upgrade/helpers/constants.py
@@ -22,7 +22,7 @@ rhelcontents = {
     },
     'capsule': {
         'prod': 'Red Hat Satellite Capsule',
-        'repofull': 'Red Hat Satellite Capsule {cap_ver} (for RHEL {os_ver} Server) (RPMs)',
+        'repofull': 'Red Hat Satellite Capsule {cap_ver} for RHEL {os_ver} Server RPMs {arch}',
         'repo': 'Red Hat Satellite Capsule {cap_ver} (for RHEL {os_ver} Server) (RPMs)',
         'label': 'rhel-{os_ver}-server-satellite-capsule-{cap_ver}-rpms'
     },

--- a/upgrade/helpers/constants.py
+++ b/upgrade/helpers/constants.py
@@ -2,7 +2,7 @@
 
 rhelcontents = {
     'rhscl': {
-        'prod': 'Red Hat Software Collections for RHEL Server',
+        'prod': 'Red Hat Software Collections (for RHEL Server)',
         'repofull': 'Red Hat Software Collections RPMs for Red Hat Enterprise Linux '
                     '{os_ver} Server {arch} {os_ver}Server',
         'repo': 'Red Hat Software Collections RPMs for Red Hat Enterprise Linux {os_ver} Server',

--- a/upgrade/helpers/constants.py
+++ b/upgrade/helpers/constants.py
@@ -22,7 +22,7 @@ rhelcontents = {
     },
     'capsule': {
         'prod': 'Red Hat Satellite Capsule',
-        'repofull': 'Red Hat Satellite Capsule {cap_ver} for RHEL {os_ver} Server (RPMs) {arch}',
+        'repofull': 'Red Hat Satellite Capsule {cap_ver} (for RHEL {os_ver} Server) (RPMs)',
         'repo': 'Red Hat Satellite Capsule {cap_ver} (for RHEL {os_ver} Server) (RPMs)',
         'label': 'rhel-{os_ver}-server-satellite-capsule-{cap_ver}-rpms'
     },

--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -380,7 +380,7 @@ def sync_tools_repos_to_upgrade(client_os, hosts):
     entities.Repository(id=tools_repo.id).sync()
     cv.repository += [tools_repo]
     cv.update(['repository'])
-    call_entity_method_with_timeout(cv.read().publish, timeout=3500)
+    call_entity_method_with_timeout(cv.read().publish, timeout=2500)
     published_ver = entities.ContentViewVersion(
         id=max([cv_ver.id for cv_ver in cv.read().version])).read()
     published_ver.promote(data={'environment_id': lenv.id, 'force': False})

--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -380,7 +380,7 @@ def sync_tools_repos_to_upgrade(client_os, hosts):
     entities.Repository(id=tools_repo.id).sync()
     cv.repository += [tools_repo]
     cv.update(['repository'])
-    call_entity_method_with_timeout(cv.read().publish, timeout=2500)
+    call_entity_method_with_timeout(cv.read().publish, timeout=3500)
     published_ver = entities.ContentViewVersion(
         id=max([cv_ver.id for cv_ver in cv.read().version])).read()
     published_ver.promote(data={'environment_id': lenv.id, 'force': False})

--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -172,7 +172,7 @@ def _sync_capsule_subscription_to_capsule_ak(ak):
             product=cap_product
         ).search()[0]
         try:
-            cap_reposet.enable(data={'releasever': '7Server'})
+            cap_reposet.enable(data={'basearch': 'x86_64', 'organization_id': org.id})
         except requests.exceptions.HTTPError:
             logger.warn('Check if reposet is already enabled, else retrigger')
         cap_repo = entities.Repository(


### PR DESCRIPTION
Satellite upgrade operation failed with below error.

```
WARNING:nailgun.client:Received HTTP 422 response: {"displayMessage":"releasever cannot be specified for Red Hat Satellite Capsule 6.4 (for RHEL 7 Server) (RPMs) as that information is not substitutable in /content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.4/os ","errors":["releasever cannot be specified for Red Hat Satellite Capsule 6.4 (for RHEL 7 Server) (RPMs) as that information is not substitutable in /content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.4/os "]}
422 Client Error: Unprocessable Entity for url: https://XYZ.redhat.com/katello/api/v2/products/29/repository_sets/7701/enable
WARNING:upgrade_logging:422 Client Error: Unprocessable Entity for url:
  File "/home/[*******]/shiningpanda/jobs/8764b415/virtualenvs/d41d8cd9/lib/python3.6/site-packages/fabric/main.py", line 763, in main
    *args, **kwargs
  File "/home/[*******]/shiningpanda/jobs/8764b415/virtualenvs/d41d8cd9/lib/python3.6/site-packages/fabric/tasks.py", line 427, in execute
    results['<local-only>'] = task.run(*args, **new_kwargs)
  File "/home/[*******]/shiningpanda/jobs/8764b415/virtualenvs/d41d8cd9/lib/python3.6/site-packages/fabric/tasks.py", line 174, in run
    return self.wrapped(*args, **kwargs)
  File "/home/[*******]/workspace/satellite6-upgrader/upgrade/runner.py", line 62, in setup_products_for_upgrade
    sat_host, os_version, False if product == 'n-1' else True)
  File "/home/[*******]/workspace/satellite6-upgrader/upgrade/capsule.py", line 93, in satellite6_capsule_setup
    execute(sync_capsule_repos_to_upgrade, cap_hosts, host=sat_host)
  File "/home/[*******]/shiningpanda/jobs/8764b415/virtualenvs/d41d8cd9/lib/python3.6/site-packages/fabric/tasks.py", line 387, in execute
    multiprocessing
  File "/home/[*******]/shiningpanda/jobs/8764b415/virtualenvs/d41d8cd9/lib/python3.6/site-packages/fabric/tasks.py", line 277, in _execute
    return task.run(*args, **kwargs)
  File "/home/[*******]/shiningpanda/jobs/8764b415/virtualenvs/d41d8cd9/lib/python3.6/site-packages/fabric/tasks.py", line 174, in run
    return self.wrapped(*args, **kwargs)
  File "/home/[*******]/workspace/satellite6-upgrader/upgrade/helpers/tasks.py", line 126, in sync_capsule_repos_to_upgrade
    _sync_capsule_subscription_to_capsule_ak(ak)
  File "/home/[*******]/workspace/satellite6-upgrader/upgrade/helpers/tasks.py", line 184, in _sync_capsule_subscription_to_capsule_ak
    ).search(query={'organization_id': org.id, 'per_page': 100})[0]
IndexError: list index out of range

```
Reason: basesearch missing and Capsule reponame was incorrect.