### PR TITLE
Add virt-who-config existence test cases

### DIFF
--- a/upgrade_tests/helpers/constants.py
+++ b/upgrade_tests/helpers/constants.py
@@ -42,7 +42,8 @@ class cli_const:
             'subnet',
             'user',
             'template',
-            'user-group'
+            'user-group',
+            'virt-who-config'
         ],
         'org_required':
         [
@@ -90,7 +91,8 @@ class cli_const:
             'sync-plan',
             'template',
             'user',
-            'user-group'
+            'user-group',
+            'virt-who-config'
         ],
         'id'
      )

--- a/upgrade_tests/test_existance_relations/cli/test_virtwho.py
+++ b/upgrade_tests/test_existance_relations/cli/test_virtwho.py
@@ -1,0 +1,73 @@
+"""Upgrade TestSuite for validating Satellite virt-who-config existence post upgrade
+
+:Requirement: Upgraded Satellite
+
+:CaseAutomation: Automated
+
+:CaseLevel: System
+
+:CaseComponent: virt-who-config
+
+:TestType: nonfunctional
+
+:CaseImportance: High
+
+:SubType1: installability
+
+:Upstream: No
+"""
+import pytest
+from upgrade_tests.helpers.common import existence
+from upgrade_tests.helpers.existence import compare_postupgrade, pytest_ids
+
+# Required Data
+component = 'virt-who-config'
+virtwho_name = compare_postupgrade(component, 'name')
+virtwho_interval = compare_postupgrade(component, 'interval')
+virtwho_status = compare_postupgrade(component, 'status')
+virtwho_last_report = compare_postupgrade(component, 'last report at')
+
+
+# Tests
+@pytest.mark.parametrize("pre,post", virtwho_name, ids=pytest_ids(virtwho_name))
+def test_positive_virt_who_by_name(pre, post):
+    """Test all virt-who configs are existing post upgrade by their name
+
+    :id: upgrade-68e6a1dd-9b65-41ee-983b-0f2101300cd8
+
+    :expectedresults: All virt-who configs should be retained post upgrade
+    """
+    assert existence(pre, post)
+
+
+@pytest.mark.parametrize("pre,post", virtwho_interval, ids=pytest_ids(virtwho_interval))
+def test_positive_virt_who_by_interval(pre, post):
+    """Test all virt-who configs interval are existing post upgrade
+
+    :id: upgrade-84702862-aef1-4b19-9007-dbb4e65a78c2
+
+    :expectedresults: All virt-who configs interval should be retained post upgrade
+    """
+    assert existence(pre, post)
+
+
+@pytest.mark.parametrize("pre,post", virtwho_status, ids=pytest_ids(virtwho_status))
+def test_positive_virt_who_by_status(pre, post):
+    """Test all virt-who configs status are existing post upgrade
+
+    :id: upgrade-54db1ea8-1cfe-4aa6-9e7e-3f7409ca2a36
+
+    :expectedresults: All virt-who configs status should be retained post upgrade
+    """
+    assert existence(pre, post)
+
+
+@pytest.mark.parametrize("pre,post", virtwho_last_report, ids=pytest_ids(virtwho_last_report))
+def test_positive_virt_who_by_last_report_time(pre, post):
+    """Test all virt-who configs last report time are existing post upgrade
+
+    :id: upgrade-a093e4a9-8cf8-4af6-a236-549e09e33c32
+
+    :expectedresults: All virt-who configs last report time should be retained post upgrade
+    """
+    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_virtwho.py
+++ b/upgrade_tests/test_existance_relations/cli/test_virtwho.py
@@ -60,14 +60,3 @@ def test_positive_virt_who_by_status(pre, post):
     :expectedresults: All virt-who configs status should be retained post upgrade
     """
     assert existence(pre, post)
-
-
-@pytest.mark.parametrize("pre,post", virtwho_last_report, ids=pytest_ids(virtwho_last_report))
-def test_positive_virt_who_by_last_report_time(pre, post):
-    """Test all virt-who configs last report time are existing post upgrade
-
-    :id: upgrade-a093e4a9-8cf8-4af6-a236-549e09e33c32
-
-    :expectedresults: All virt-who configs last report time should be retained post upgrade
-    """
-    assert existence(pre, post)

--- a/upgrade_tests/test_existance_relations/cli/test_virtwho.py
+++ b/upgrade_tests/test_existance_relations/cli/test_virtwho.py
@@ -25,7 +25,6 @@ component = 'virt-who-config'
 virtwho_name = compare_postupgrade(component, 'name')
 virtwho_interval = compare_postupgrade(component, 'interval')
 virtwho_status = compare_postupgrade(component, 'status')
-virtwho_last_report = compare_postupgrade(component, 'last report at')
 
 
 # Tests


### PR DESCRIPTION
**Description**
Add virt-who-config cli existence test cases

use hammer command to list virt-who-config entities:
```
[root@qe-sat6-upgrade-rhel7 ~]# hammer virt-who-config list
[Foreman] Username: admin
[Foreman] Password for admin: 
---|---------------------|------------|--------|--------------------
ID | NAME                | INTERVAL   | STATUS | LAST REPORT AT     
---|---------------------|------------|--------|--------------------
1  | preupgrade_virt_who | every hour | OK     | 2020/01/06 08:33:57
---|---------------------|------------|--------|--------------------

```


**Test Result**
```
(upgrade) [hkx303@kuhuang satellite6-upgrade]$ py.test --junit-xml=reports.xml --continue-on-collection-errors upgrade_tests/test_existance_relations/cli/test_virtwho.py 
======================================================================== test session starts =========================================================================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
rootdir: /home/hkx303/Documents/CI/satellite6-upgrade/satellite6-upgrade
plugins: cov-2.8.1
collected 4 items                                                                                                                                                    

upgrade_tests/test_existance_relations/cli/test_virtwho.py ....                                                                                                [100%]

================================================================ 4 passed, 3 warnings in 0.24 seconds ================================================================
```