### PR TITLE
Updated capsule installer option details

### DIFF
--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -1091,7 +1091,7 @@ def upgrade_task(upgrade_type, cap_host=None):
     """
     if cap_host:
         run('satellite-installer --scenario {0} --upgrade '
-            '--certs-tar /home/{1}-certs.tar '
+            '--certs-tar-file /home/{1}-certs.tar '
             '--certs-update-all'.format(upgrade_type, cap_host))
     else:
         run('satellite-installer --scenario {} --upgrade'.format(upgrade_type))


### PR DESCRIPTION
 Satellite-installer command failed in capsule upgrade due to unrecognised option. 

```
# satellite-installer --scenario capsule --upgrade --certs-tar xyz.com-certs.tar --certs-update-all
ERROR: Unrecognised option '--certs-tar'
```