### PR TITLE
Removed "releasever" from capsule repostory enable data.

### DIFF
--- a/upgrade/helpers/constants.py
+++ b/upgrade/helpers/constants.py
@@ -26,7 +26,7 @@ rhelcontents = {
     'capsule': {
         'prod': 'Red Hat Satellite Capsule',
         'repofull': 'Red Hat Satellite Capsule {cap_ver} for RHEL {os_ver} Server RPMs '
-                    '{arch} {os_ver}Server',
+                    '{arch}',
         'repo': 'Red Hat Satellite Capsule {cap_ver} (for RHEL {os_ver} Server) (RPMs)',
         'label': 'rhel-{os_ver}-server-satellite-capsule-{cap_ver}-rpms'
     },

--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -200,7 +200,7 @@ def _sync_capsule_subscription_to_capsule_ak(ak):
                            .format(cap_ver=to_version, os_ver=os_ver)))
         try:
             cap_reposet.enable(
-                data={'basearch': 'x86_64', 'releasever': '7Server', 'organization_id': org.id})
+                data={'basearch': 'x86_64', 'organization_id': org.id})
         except requests.exceptions.HTTPError as exp:
             logger.warn(exp)
         cap_repo = entities.Repository(
@@ -901,8 +901,12 @@ def wait_untill_capsule_sync(capsule):
         logger.info(
             'Wait for background capsule sync to finish on '
             'capsule: {}'.format(cap.name))
+        start_time = job_execution_time("capsule_sync")
         for task in active_tasks:
-            entities.ForemanTask(id=task['id']).poll(timeout=2700)
+            entities.ForemanTask(id=task['id']).poll(timeout=9000)
+        job_execution_time("Background capsule sync operation(In past time-out value was "
+                           "2700 but in current execution we have set it 9000)",
+                           start_time)
 
 
 def pre_upgrade_system_checks(capsules):


### PR DESCRIPTION
The fix is required to enable the repository, In 6.6 "releasever" has removed from capsule repositories details.