### PR TITLE
Replaced katello-service with foreman-maintain service.

### DIFF
--- a/upgrade/capsule.py
+++ b/upgrade/capsule.py
@@ -12,7 +12,7 @@ from upgrade.helpers.rhevm4 import (
 from upgrade.helpers.tasks import (
     sync_capsule_repos_to_upgrade,
     add_baseOS_repo,
-    foreman_packages_installation_check,
+    foreman_service_restart,
     nonfm_upgrade,
     upgrade_validation,
     setup_foreman_maintain_repo,
@@ -83,7 +83,7 @@ def satellite6_capsule_setup(sat_host, os_version, upgradable_capsule=True):
                 non_responsive_host.append(cap_host)
             else:
                 execute(host_ssh_availability_check, cap_host)
-                execute(lambda: run('katello-service restart'), host=cap_host)
+                execute(foreman_service_restart, host=cap_host)
         if non_responsive_host:
             logger.warning(str(non_responsive_host) + ' these are '
                                                       'non-responsive hosts')
@@ -131,7 +131,6 @@ def satellite6_capsule_upgrade(cap_host, sat_host):
     disable_old_repos('rhel-{0}-server-satellite-capsule-{1}-rpms'.format(
         major_ver, from_version))
     # setup foreman-maintain
-    foreman_packages_installation_check(state="unlock")
     setup_foreman_maintain_repo()
     # Check what repos are set
 
@@ -139,7 +138,6 @@ def satellite6_capsule_upgrade(cap_host, sat_host):
                   cap_host=cap_host,
                   sat_host=sat_host)
     # Rebooting the capsule for kernel update if any
-    foreman_packages_installation_check(state="lock")
     reboot(160)
     host_ssh_availability_check(cap_host)
     # Check if Capsule upgrade is success
@@ -171,9 +169,7 @@ def satellite6_capsule_zstream_upgrade(cap_host):
         disable_old_repos('rhel-{0}-server-satellite-capsule-{1}-rpms'.format(
             major_ver, from_version))
     # Check what repos are set
-    foreman_packages_installation_check(state="unlock")
     nonfm_upgrade(satellite_upgrade=False)
-    foreman_packages_installation_check(state="lock")
     # Rebooting the capsule for kernel update if any
     reboot(160)
     host_ssh_availability_check(cap_host)

--- a/upgrade/helpers/rhevm.py
+++ b/upgrade/helpers/rhevm.py
@@ -12,7 +12,7 @@ from upgrade.helpers.tasks import (
     check_necessary_env_variables_for_upgrade,
     capsule_sync,
     check_ntpd,
-    katello_restart,
+    foreman_service_restart,
 )
 
 
@@ -282,10 +282,10 @@ def validate_and_create_product_templates(product):
         new_cap_template = os.environ.get('RHEV_CAP_IMAGE') + "_new"
         if check_necessary_env_variables_for_upgrade('capsule'):
             execute(check_ntpd, host=sat_host)
-            execute(katello_restart, host=sat_host)
+            execute(foreman_service_restart, host=sat_host)
             execute(capsule_sync, cap_host, host=sat_host)
             execute(check_ntpd, host=cap_host)
-            execute(katello_restart, host=cap_host)
+            execute(foreman_service_restart, host=cap_host)
             thread.start_new_thread(create_rhevm_template,
                                     (sat_instance,
                                      cluster,

--- a/upgrade/helpers/rhevm4.py
+++ b/upgrade/helpers/rhevm4.py
@@ -15,7 +15,7 @@ from upgrade.helpers.tasks import (
     check_necessary_env_variables_for_upgrade,
     capsule_sync,
     check_ntpd,
-    katello_restart,
+    foreman_service_restart,
 )
 
 
@@ -290,10 +290,10 @@ def validate_and_create_rhevm4_templates(product):
         new_cap_template = os.environ.get('RHEV_CAP_IMAGE') + "_new"
         if check_necessary_env_variables_for_upgrade('capsule'):
             execute(check_ntpd, host=sat_host)
-            execute(katello_restart, host=sat_host)
+            execute(foreman_service_restart, host=sat_host)
             execute(capsule_sync, cap_host, host=sat_host)
             execute(check_ntpd, host=cap_host)
-            execute(katello_restart, host=cap_host)
+            execute(foreman_service_restart, host=cap_host)
             _thread.start_new_thread(
                 create_rhevm4_template,
                 (

--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -614,7 +614,7 @@ def post_upgrade_test_tasks(sat_host, cap_host=None):
     # Increase log level to DEBUG, to get better logs in foreman_debug
     execute(lambda: run('sed -i -e \'/:level: / s/: .*/: '
                         'debug/\' /etc/foreman/settings.yaml'), host=sat_host)
-    execute(lambda: run('katello-service restart'), host=sat_host)
+    execute(foreman_service_restart, host=sat_host)
     # Execute task for template changes required for discovery feature
     execute(
         setup_foreman_discovery,
@@ -663,9 +663,9 @@ def capsule_sync(cap_host):
     job_execution_time("Capsule content sync operation", start_time)
 
 
-def katello_restart():
-    """Restarts the katello services"""
-    services = run('katello-service restart')
+def foreman_service_restart():
+    """Restarts the foreman-maintain services"""
+    services = run('foreman-maintain service restart')
     if services.return_code > 0:
         logger.error('Unable to re-start the Satellite Services')
         sys.exit(1)
@@ -1090,7 +1090,7 @@ def nonfm_upgrade(satellite_upgrade=True,
                   cap_host=None, sat_host=None):
     """
     The purpose of this module to perform the upgrade task without foreman-maintain.
-    In this function we setup the repository, stop the katello services,
+    In this function we setup the repository, stop the foreman-maintain services,
     cleanup, and execute satellite upgrade task"
     :param bool satellite_upgrade: If satellite_upgrade is True then upgrade
     type satellite otherwise capsule
@@ -1104,8 +1104,8 @@ def nonfm_upgrade(satellite_upgrade=True,
     # Check what repos are set
     upgrade_type = "satellite" if satellite_upgrade else "capsule"
     run('yum repolist')
-    # Stop katello services, except mongod
-    run('katello-service stop')
+    # Stop foreman-maintain services
+    run('foreman-maintain service stop')
     run('yum clean all', warn_only=True)
     # Updating the packages again after setting sat6 repo
     logger.info('Updating system and {} packages... '.format(upgrade_type))
@@ -1155,11 +1155,8 @@ def upgrade_validation(upgrade_type=False):
     :param bool upgrade_type: if upgrade_type is True then we check both the services.
     """
     if upgrade_type:
-        # This command will be used only with 6.7 for more reference Please
-        # look into BZ#1771531
-        run('hammer --reload-cache')
         run('hammer ping', warn_only=True)
-    run('katello-service status', warn_only=True)
+    run('foreman-maintain service status', warn_only=True)
 
 
 def update_scap_content():

--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -22,6 +22,7 @@ from upgrade.helpers.tasks import (
     enable_disable_repo,
     foreman_packages_installation_check,
     foreman_maintain_upgrade,
+    foreman_service_restart,
     repository_setup,
     repository_cleanup,
     setup_foreman_maintain,
@@ -67,7 +68,7 @@ def satellite6_setup(os_version):
         execute(install_prerequisites, host=sat_host)
         # Subscribe the instance to CDN
         execute(subscribe, host=sat_host)
-        execute(lambda: run('katello-service restart'), host=sat_host)
+        execute(foreman_service_restart, host=sat_host)
     # Set satellite hostname in fabric environment
     env['satellite_host'] = sat_host
     logger.info('Satellite {} is ready for Upgrade!'.format(sat_host))


### PR DESCRIPTION
katello-service has deprecated in 6.8, therefore we have used foreman-maintain service at the place of katello-service.