### PR TITLE
Update dependencies shared with Robottelo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Fabric3',
-        'fauxfactory==3.0.2',
+        'fauxfactory>=3.0.6',
         'ovirt-engine-sdk-python',
         'pycurl',
         'pytest==4.6.3',


### PR DESCRIPTION
This change is motivated by upcoming dependency resolver change in pip:
```
$ cd robottelo
$ pip --use-feature=2020-resolver install -r requirements.txt
(...)
ERROR: Cannot install fauxfactory==3.0.6, -r requirements.txt (line 25), -r requirements.txt (line 32), -r requirements.txt (line 33) and -r requirements.txt (line 34) because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested fauxfactory==3.0.6
    wrapanapi 3.2.0 depends on fauxfactory>=2.0.7
    airgun 0.0.1 depends on fauxfactory
    nailgun 0.32.0 depends on fauxfactory
    satellite6-upgrade 0.1.0 depends on fauxfactory==3.0.2
```

See https://pythoninsider.blogspot.com/2020/07/upgrade-pip-20-2-changes-20-3.html for context and detailed documentation.

fauxfactory 3.0.6, when compared with 3.0.2, contains mostly house-keeping changes (docs, tests, setup). Some function signatures did change, but in backwards-compatible way.

I have not checked ovirt-engine-sdk-python changes upstream.

I haven't run robottelo or satellite6-upgrade after this commit, I only checked if Robottelo can be properly installed.