### PR TITLE
Updated the capsule repository name

### DIFF
--- a/upgrade/helpers/constants.py
+++ b/upgrade/helpers/constants.py
@@ -26,7 +26,7 @@ rhelcontents = {
     'capsule': {
         'prod': 'Red Hat Satellite Capsule',
         'repofull': 'Red Hat Satellite Capsule {cap_ver} for RHEL {os_ver} Server RPMs '
-                    '{arch} {os_ver}Server',
+                    '{arch}',
         'repo': 'Red Hat Satellite Capsule {cap_ver} (for RHEL {os_ver} Server) (RPMs)',
         'label': 'rhel-{os_ver}-server-satellite-capsule-{cap_ver}-rpms'
     },


### PR DESCRIPTION
The upgrade execution failed with error"IndexError: list index out of range", The problem came due to capsule repository name changed from "Red Hat Satellite Capsule 6.7 for RHEL 7 Server RPMs x86_64 7Server" to "Red Hat Satellite Capsule 6.7 for RHEL 7 Server RPMs x86_64" 
