### PR TITLE
Update nailgun to point to master branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Get automation-tools from master
-git+https://github.com/SatelliteQE/automation-tools#egg=automation-tools
+git+https://github.com/SatelliteQE/automation-tools@master#egg=automation-tools
 
 # Get nailgun from master
-git+https://github.com/SatelliteQE/nailgun.git@stable-satellite#egg=nailgun
+git+https://github.com/SatelliteQE/nailgun.git@master#egg=nailgun
 
 --editable .


### PR DESCRIPTION
Following suit with Robottelo, deprecating use of stable-satellite branch in nailgun.