### PR TITLE
[6.8.z] Update pinning of pytest==5.4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'fauxfactory==3.0.2',
         'ovirt-engine-sdk-python',
         'pycurl',
-        'pytest==4.6.3',
+        'pytest==5.4.3',
         'python-bugzilla==1.2.2',
         'requests',
         'robozilla',


### PR DESCRIPTION
To match pinning at *robottelo* 6.8.z branch
As https://github.com/SatelliteQE/robottelo/pull/8031 went to `master` before `6.8.z` was branched

This is no upgrade as 5.4.3 is used anyway but there is warning about newer pytest used