### PR TITLE
[6.7.z] Update pinning of pytest==4.6.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'fauxfactory==3.0.2',
         'ovirt-engine-sdk-python',
         'pycurl',
-        'pytest==4.6.3',
+        'pytest==4.6.11',
         'python-bugzilla==1.2.2',
         'requests',
         'robozilla',


### PR DESCRIPTION
To match pinning at **robottelo** 6.7.z branch
As https://github.com/SatelliteQE/robottelo/pull/8145 is about to go to `6.7.z`