### PR TITLE
Updated content view promote API

### DIFF
--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -148,9 +148,7 @@ def sync_capsule_repos_to_upgrade(capsules):
         # Fix of 1770940, 1773601
         logger.info("Resuming the cancelled content view {} publish task"
                     .format(cv.name))
-        output = run(
-            "sleep 100; hammer task resume|grep ') Task identifier:'|"
-            "awk -F':' '{print $2}'; sleep 100")
+        output = run("sleep 100; hammer task list|awk '/Task canceled/{print $1}'; sleep 100")
         for task_id in output.split():
             run('hammer task progress --id {}'.format(task_id))
         job_execution_time("Content view {} publish operation(In past time-out value was "
@@ -161,7 +159,7 @@ def sync_capsule_repos_to_upgrade(capsules):
         id=max([cv_ver.id for cv_ver in cv.read().version])).read()
     logger.info("Content view {} promotion has started successfully".
                 format(cv.name))
-    published_ver.promote(data={'environment_id': lenv.id, 'force': False})
+    published_ver.promote(data={'environment_ids': [lenv.id], 'force': False})
     logger.info("Content view {} promotion has completed successfully".
                 format(cv.name))
     # Add capsule and tools custom prod subscription to capsules
@@ -523,8 +521,7 @@ def sync_tools_repos_to_upgrade(client_os, hosts):
         # Fix of 1770940, 1773601
         logger.info("Resuming the cancelled content view {} publish task"
                     .format(cv.name))
-        output = run("sleep 100; hammer task resume|grep ') Task identifier:'|"
-                     "awk -F':' '{print $2}'; sleep 100")
+        output = run("sleep 100; hammer task list|awk '/Task canceled/{print $1}';sleep 100")
         logger.info("The CV publish task {} has resumed successfully, "
                     "waiting for their completion".format(output))
         for task_id in output.split():
@@ -540,7 +537,7 @@ def sync_tools_repos_to_upgrade(client_os, hosts):
     start_time = job_execution_time("CV_Promotion")
     logger.info("Published CV {} version promotion is started successfully"
                 .format(cv.name))
-    published_ver.promote(data={'environment_id': lenv.id, 'force': False})
+    published_ver.promote(data={'environment_ids': [lenv.id], 'force': False})
     job_execution_time("Content view {} promotion ".format(cv.name), start_time)
     logger.info("Published CV {} version has promoted successfully".format(cv.name))
     tools_sub = entities.Subscription().search(


### PR DESCRIPTION
There is an issue observed in 6.8 content view version update API's, in 6.8 environment id parameter has changed from "environment_id" to "environment ids"

**Before API Update**

```
>>> published_ver.promote(data={'environment_id': lenv.id, 'force': False})
WARNING:nailgun.client:Received HTTP 400 response: {"displayMessage":"Could not find environments for promotion","errors":["Could not find environments for promotion"]}
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/desingh/Satellite-QE/global_compiler/upgrade_pyenv/lib/python3.6/site-packages/nailgun/entities.py", line 2208, in promote
    response = client.post(self.path('promote'), **kwargs)
  File "/home/desingh/Satellite-QE/global_compiler/upgrade_pyenv/lib/python3.6/site-packages/nailgun/entities.py", line 111, in _handle_response
    response.raise_for_status()
  File "/home/desingh/Satellite-QE/global_compiler/upgrade_pyenv/lib/python3.6/site-packages/requests/models.py", line 943, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://XYZ.com/katello/api/v2/content_view_versions/123/promote
```

**After API update**
```
>>> published_ver.promote(data={'environment_ids':lenv.id, 'force': False})
{'id': '09fa61f5-6d28-4abc-8a1a-a7b848a2febc', 'label': 'Actions::Katello::ContentView::Promote', 'pending': False, 'action': "Promote content view 'rhel7_capsule_cv'; organization 'Default Organization'", 'username': 'admin', 'started_at': '2020-11-18 07:11:01 UTC', 'ended_at': '2020-11-18 07:13:46 UTC', 'state': 'stopped', 'result': 'success', 'progress': 1.0, 'input': {'content_view': {'id': 4, 'name': 'rhel7_capsule_cv', 'label': 'rhel7_capsule_cv'}, 'organization': {'id': 1, 'name': 'Default Organization', 'label': 'Default_Organization'}, 'environments': ['Dev'], 'services_checked': ['pulp', 'pulp_auth', 'candlepin', 'candlepin_auth'], 'current_request_id': None, 'current_timezone': 'UTC', 'current_user_id': 3, 'current_organization_id': None, 'current_location_id': None}, 'output': {}, 'humanized': {'action': 'Promote', 'input': [['content_view', {'text': "content view 'rhel7_capsule_cv'", 'link': '/content_views/4/versions'}], ['organization', {'text': "organization 'Default Organization'", 'link': '/organizations/1/edit'}]], 'output': '', 'errors': []}, 'cli_example': None, 'start_at': '2020-11-18 07:11:01 UTC', 'available_actions': {'cancellable': False, 'resumable': False}}
>>> 
```

