### PR TITLE
[6.8.z] Update pinning to fauxfactory==3.0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Fabric3',
-        'fauxfactory==3.0.2',
+        'fauxfactory==3.0.6',
         'ovirt-engine-sdk-python',
         'pycurl',
         'pytest==5.4.3',


### PR DESCRIPTION
update pinning from `fauxfactory==3.0.2` to `fauxfactory==3.0.6` in order to match robottelo 6.8.z branch