### PR TITLE
Updated the Satellite and Capsule upgrade workflow for new infra.

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -32,6 +32,7 @@ from upgrade.helpers.tools import get_sat_cap_version
 from upgrade.helpers.tools import host_pings
 from upgrade.helpers.tools import host_ssh_availability_check
 from upgrade.helpers.tools import reboot
+from upgrade.runner import product_setup_for_upgrade_on_brokers_machine
 from upgrade.runner import product_upgrade
 from upgrade.runner import setup_products_for_upgrade
 from upgrade.satellite import satellite6_setup

--- a/upgrade/client.py
+++ b/upgrade/client.py
@@ -8,6 +8,10 @@ from fabric.api import env
 from fabric.api import execute
 from fabric.api import run
 
+from upgrade.helpers.constants import RHEV_CLIENT_AK_RHEL6
+from upgrade.helpers.constants import RHEV_CLIENT_AK_RHEL7
+from upgrade.helpers.constants import TOOLS_URL_RHEL6
+from upgrade.helpers.constants import TOOLS_URL_RHEL7
 from upgrade.helpers.docker import docker_execute_command
 from upgrade.helpers.docker import generate_satellite_docker_clients_on_rhevm
 from upgrade.helpers.docker import refresh_subscriptions_on_docker_clients
@@ -48,14 +52,16 @@ def satellite6_client_setup():
         if os.environ.get('TOOLS_URL_RHEL6'):
             logger.info('Syncing Tools repos of rhel6 in Satellite:')
             execute(
-                sync_tools_repos_to_upgrade, 'rhel6', clients6, host=sat_host)
+                sync_tools_repos_to_upgrade, 'rhel6', clients6,
+                TOOLS_URL_RHEL6, RHEV_CLIENT_AK_RHEL6, host=sat_host)
     if clients7:
         clients7 = [client.strip() for client in str(clients7).split(',')]
         # Sync latest sat tools repo to clients if downstream
         if os.environ.get('TOOLS_URL_RHEL7'):
             logger.info('Syncing Tools repos of rhel7 in Satellite:')
             execute(
-                sync_tools_repos_to_upgrade, 'rhel7', clients7, host=sat_host)
+                sync_tools_repos_to_upgrade, 'rhel7', clients7, TOOLS_URL_RHEL7,
+                RHEV_CLIENT_AK_RHEL7, host=sat_host)
     # Run upgrade on Docker Containers
     if not all([clients6, clients7]):
         if not clients_count:
@@ -131,6 +137,8 @@ def satellite6_client_setup():
                 # Containers_ids are not required from sat version > 6.1 to
                 # attach the subscription to client
                 all_clients7,
+                TOOLS_URL_RHEL7,
+                RHEV_CLIENT_AK_RHEL7,
                 host=sat_host
             )
             time.sleep(10)
@@ -141,6 +149,8 @@ def satellite6_client_setup():
                 # Containers_ids are not requied from sat version > 6.1 to
                 # attach the subscriprion to client
                 all_clients6,
+                TOOLS_URL_RHEL6,
+                RHEV_CLIENT_AK_RHEL6,
                 host=sat_host
             )
         # Refresh subscriptions on clients

--- a/upgrade/helpers/__init__.py
+++ b/upgrade/helpers/__init__.py
@@ -1,6 +1,0 @@
-from nailgun.config import ServerConfig
-
-from upgrade.helpers.tasks import get_satellite_host
-
-sat_url = 'https://{}'.format(get_satellite_host())
-ServerConfig(url=sat_url, auth=['admin', 'changeme'], verify=False).save()

--- a/upgrade/helpers/constants/__init__.py
+++ b/upgrade/helpers/constants/__init__.py
@@ -1,0 +1,30 @@
+from os import environ
+
+
+FROM_VERSION = environ.get('FROM_VERSION')
+TO_VERSION = environ.get('TO_VERSION')
+
+OS = environ.get('OS')
+
+CAPSULE_REPO = environ.get('CAPSULE_URL')
+
+TOOLS_URL_RHEL6 = environ.get('TOOLS_URL_RHEL6')
+TOOLS_URL_RHEL7 = environ.get('TOOLS_URL_RHEL7')
+MAINTAIN_REPO = environ.get('MAINTAIN_REPO')
+
+RHEV_CLIENT_AK_RHEL6 = environ.get('RHEV_CLIENT_AK_RHEL6')
+RHEV_CLIENT_AK_RHEL7 = environ.get('RHEV_CLIENT_AK_RHEL7')
+RHEV_CAPSULE_AK = environ.get('RHEV_CAPSULE_AK')
+
+BASE_URL = environ.get('BASE_URL')
+CAPSULE_URL = environ.get('CAPSULE_URL')
+
+PRODUCTS = ['satellite', 'capsule', 'client', 'longrun', 'n-1']
+
+LIBVERT_HOSTNAME = environ.get('LIBVIRT_HOSTNAME')
+
+FAKE_MANIFEST_CERT_URL = environ.get('FAKE_MANIFEST_CERT_URL')
+
+DISTRIBUTION = environ.get('DISTRIBUTION')
+BASE_URL = environ.get('BASE_URL')
+DOCKER_VM = environ.get('DOCKER_VM')

--- a/upgrade/helpers/constants/repos.py
+++ b/upgrade/helpers/constants/repos.py
@@ -1,4 +1,4 @@
-"""Upgrade needed Constants"""
+"""Constants Repo"""
 
 rhelcontents = {
     'rhscl': {

--- a/upgrade/runner.py
+++ b/upgrade/runner.py
@@ -3,7 +3,6 @@
 Many commands are affected by environment variables. Unless stated otherwise,
 all environment variables are required.
 """
-import os
 from distutils.version import LooseVersion
 
 from automation_tools import foreman_debug
@@ -14,8 +13,11 @@ from fabric.api import execute
 from upgrade.capsule import satellite6_capsule_setup
 from upgrade.capsule import satellite6_capsule_upgrade
 from upgrade.capsule import satellite6_capsule_zstream_upgrade
+from upgrade.capsule import satellite_capsule_setup
 from upgrade.client import satellite6_client_setup
 from upgrade.client import satellite6_client_upgrade
+from upgrade.helpers.constants import FROM_VERSION
+from upgrade.helpers.constants import TO_VERSION
 from upgrade.helpers.logger import logger
 from upgrade.helpers.tasks import check_necessary_env_variables_for_upgrade
 from upgrade.helpers.tasks import post_upgrade_test_tasks
@@ -25,13 +27,48 @@ from upgrade.helpers.tools import get_sat_cap_version
 from upgrade.helpers.tools import get_setup_data
 from upgrade.satellite import satellite6_setup
 from upgrade.satellite import satellite6_upgrade
+from upgrade.satellite import satellite_setup
 
-
-# =============================================================================
-# Satellite, Capsule and Client Upgrade
-# =============================================================================
 
 logger = logger()
+
+
+def product_setup_for_upgrade_on_brokers_machine(product, os_version, satellite, capsule=None):
+    """
+    Sets up product(s) to perform upgrade on Satellite, Capsule and content host
+    :param string product: The product name to setup before upgrade
+    :param string os_version: The os version on which product is installed e.g: rhel6, rhel7
+    :param satellite: brokers/users provided satellite
+    :param capsule: brokers/users provided capsules, if the capsules count more than one then
+     we keep them separate by a semicolon examplet: test1.xyz.com;test2.xyz.com
+    """
+    sat_host = satellite
+    cap_hosts = None
+    clients6 = clients7 = puppet_clients7 = puppet_clients6 = None
+    env.disable_known_hosts = True
+    check_necessary_env_variables_for_upgrade(product)
+
+    clients6 = clients7 = puppet_clients7 = puppet_clients6 = None
+    logger.info('Setting up Satellite ....')
+    sat_host = satellite_setup(sat_host)
+    if product == 'capsule' or product == 'n-1' or product == 'longrun':
+        cap_hosts = capsule.split(';')
+        logger.info('Setting up Capsule ....')
+        cap_hosts = satellite_capsule_setup(
+            sat_host, cap_hosts, os_version, False if product == 'n-1' else True)
+    if product == 'client' or product == 'longrun':
+        logger.info('Setting up Clients ....')
+        clients6, clients7, puppet_clients7, puppet_clients6 = satellite6_client_setup()
+
+    setups_dict = {
+        'sat_host': sat_host,
+        'capsule_hosts': cap_hosts,
+        'clients6': clients6,
+        'clients7': clients7,
+        'puppet_clients7': puppet_clients7,
+        'puppet_clients6': puppet_clients6
+    }
+    create_setup_dict(setups_dict)
 
 
 def setup_products_for_upgrade(product, os_version):
@@ -42,209 +79,136 @@ def setup_products_for_upgrade(product, os_version):
         e.g: rhel6, rhel7
     """
     env.disable_known_hosts = True
-    if check_necessary_env_variables_for_upgrade(product):
-        sat_host = cap_hosts = None
-        clients6 = clients7 = puppet_clients7 = puppet_clients6 = None
-        logger.info('Setting up Satellite ....')
-        sat_host = satellite6_setup(os_version)
-        if product == 'capsule' or product == 'n-1' or product == 'longrun':
-            logger.info('Setting up Capsule ....')
-            cap_hosts = satellite6_capsule_setup(
-                sat_host, os_version, False if product == 'n-1' else True)
-        if product == 'client' or product == 'longrun':
-            logger.info('Setting up Clients ....')
-            clients6, clients7, puppet_clients7, puppet_clients6 = satellite6_client_setup()
-        setups_dict = {
-            'sat_host': sat_host,
-            'capsule_hosts': cap_hosts,
-            'clients6': clients6,
-            'clients7': clients7,
-            'puppet_clients7': puppet_clients7,
-            'puppet_clients6': puppet_clients6
-        }
-        create_setup_dict(setups_dict)
-        return (
-            sat_host, cap_hosts, clients6, clients7,
-            puppet_clients7, puppet_clients6)
+    sat_host = cap_hosts = None
+    clients6 = clients7 = puppet_clients7 = puppet_clients6 = None
+    logger.info('Setting up Satellite ....')
+    sat_host = satellite6_setup(os_version)
+    if product == 'capsule' or product == 'n-1' or product == 'longrun':
+        logger.info('Setting up Capsule ....')
+        cap_hosts = satellite6_capsule_setup(
+            sat_host, os_version, False if product == 'n-1' else True)
+    if product == 'client' or product == 'longrun':
+        logger.info('Setting up Clients ....')
+        clients6, clients7, puppet_clients7, puppet_clients6 = satellite6_client_setup()
+    setups_dict = {
+        'sat_host': sat_host,
+        'capsule_hosts': cap_hosts,
+        'clients6': clients6,
+        'clients7': clients7,
+        'puppet_clients7': puppet_clients7,
+        'puppet_clients6': puppet_clients6
+    }
+    create_setup_dict(setups_dict)
+    return (
+        sat_host, cap_hosts, clients6, clients7,
+        puppet_clients7, puppet_clients6)
 
 
-def product_upgrade(product):
-    """Task which upgrades the product.
-
-    Product is satellite or capsule or client or longrun.
-    If product is satellite then upgrade only satellite
-    If product is capsule then upgrade satellite and capsule
-    If product is client then upgrade satellite and client
-    If product is longrun then upgrade satellite, capsule and client
-    If product is n-1 then upgrades only satellite by keeping capsule at last
-    z-stream released version
-
-    :param string product: product name wanted to upgrade.
-
-    Environment Variables necessary to proceed Upgrade:
-    -----------------------------------------------------
-
-    FROM_VERSION
-        The satellite/capsule current version to upgrade to latest.
-        e.g '6.2','6.1'
-    TO_VERSION
-        To which Satellite/Capsule version to upgrade.
-        e.g '6.3','6.2'
-    OS
-        The OS Version on which the satellite is installed.
-        e.g 'rhel7','rhel6'
-
-    Environment variables populated from jenkins:
-    ------------------------------------------------------
-
-    RHN_USERNAME
-        Red Hat Network username to register the system.
-    RHN_PASSWORD
-        Red Hat Network password to register the system.
-    RHN_POOLID
-        Optional. Red Hat Network pool ID. Determines what software will be
-        available from RHN
-    BASE_URL
-        URL for the compose repository.
-    CAPSULE_URL
-        The url for capsule repo from latest satellite compose.
-        If CDN, defaults to latest available capsule version
-    TOOLS_URL_RHEL6
-        The url for rhel6 tools repo from latest satellite compose
-        If CDN, defaults to latest available tools version
-    TOOLS_URL_RHEL7
-        The url for rhel7 tools repo from latest satellite compose
-        If CDN, defaults to latest available tools version
-
-    Environment variables required to run upgrade on user's own setup:
-    --------------------------------------------------------------------
-
-    SATELLITE_HOSTNAME
-        The Satellite hostname to run upgrade on
-    CAPSULE_HOSTNAME
-        The Satellite hostname to run upgrade on
-    CLIENT6_HOSTS
-        The RHEL6 clients hostnames to run upgrade on
-    CLIENT7_HOSTS
-        The RHEL7 clients hostnames to run upgrade on.
-    CAPSULE_AK
-        Activation Key name attached to the subscription of capsule
-    CLIENT_AK
-        Activation Key name attached to the subscription of client
-
-    Environment variables required to run upgrade on RHEVM Setup and will be
-    fetched from Jenkins:
-    ----------------------------------------------------------------------
-
-    RHEV_SAT_IMAGE
-        The satellite Image from which satellite instance will be created
-    RHEV_SAT_HOST
-        The rhevm satellite hostname to run upgrade on
-    RHEV_CAP_IMAGE
-        The capsule Image from which capsule instance will be created
-    RHEV_CAP_HOST
-        The rhevm capsule hostname to run upgrade on
-    DOCKER_VM
-        The Docker VM IP/Hostname on rhevm to create and upgrade clients
-    CLIENTS_COUNT
-        The number of clients(docker containers) to generate to run upgrade
-    RHEV_CAPSULE_AK
-        The AK name used in capsule subscription
-    RHEV_CLIENT_AK
-        The AK name used in client subscription
+def product_upgrade(product, upgrade_type):
     """
-    env.disable_known_hosts = True
-    if check_necessary_env_variables_for_upgrade(product):
-        from_version = os.environ.get('FROM_VERSION')
-        to_version = os.environ.get('TO_VERSION')
-        logger.info('Performing UPGRADE FROM {0} TO {1}'.format(
-            from_version, to_version))
-        # Get the setup dict returned by setup_products_for_upgrade
-        setup_dict = get_setup_data()
-        sat_host = setup_dict['sat_host']
-        cap_hosts = setup_dict['capsule_hosts']
-        env['satellite_host'] = sat_host
-        pre_upgrade_system_checks(cap_hosts)
+    Used to drive the satellite, Capsule and Content-host upgrade based on their
+    product type and upgrade type
+
+    :param product: Product can be satellite, capsule, longrun and n-1
+
+        1- If product is satellite then upgrade only satellite
+        2- If product is capsule then upgrade satellite and capsule
+        3- If product is client then upgrade satellite and client
+        4- If product is longrun then upgrade satellite, capsule and client
+        5- If product is n-1 then upgrades only satellite by keeping capsule at last
+        z-stream released version
+
+    :param upgrade_type: Upgrade_type can be satellite, capsule and client
+
+
+    """
+    def product_upgrade_satellite(sat_host):
         try:
             with LogAnalyzer(sat_host):
                 current = execute(
                     get_sat_cap_version, 'sat', host=sat_host)[sat_host]
-                if from_version != to_version:
+                if FROM_VERSION != TO_VERSION:
                     execute(satellite6_upgrade, host=sat_host)
                 else:
                     execute(satellite6_upgrade, True, host=sat_host)
                 upgraded = execute(
                     get_sat_cap_version, 'sat', host=sat_host)[sat_host]
-                if LooseVersion(upgraded) > LooseVersion(current):
-                    logger.highlight(
-                        'The Satellite is upgraded from {0} to {1}'.format(
-                            current, upgraded))
-                else:
-                    logger.highlight(
-                        'The Satellite is NOT upgraded to next version. Now '
-                        'its {}'.format(upgraded))
-                # Generate foreman debug on satellite after upgrade
-                execute(foreman_debug, 'satellite_{}'.format(sat_host),
-                        host=sat_host)
-                if product == 'capsule' or product == 'longrun':
-                    for cap_host in cap_hosts:
-                        try:
-                            with LogAnalyzer(cap_host):
-                                current = execute(
-                                    get_sat_cap_version, 'cap', host=cap_host)[cap_host]
-                                if from_version != to_version:
-                                    execute(satellite6_capsule_upgrade,
-                                            cap_host, sat_host, host=cap_host)
-                                elif from_version == to_version:
-                                    execute(satellite6_capsule_zstream_upgrade,
-                                            cap_host, host=cap_host)
-                                upgraded = execute(
-                                    get_sat_cap_version, 'cap', host=cap_host)[cap_host]
-                                if current:
-                                    if LooseVersion(upgraded) > LooseVersion(
-                                            current):
-                                        logger.highlight(
-                                            'The Capsule is upgraded from {0} '
-                                            'to {1}.'.format(current, upgraded)
-                                        )
-                                    else:
-                                        logger.highlight(
-                                            'The Capsule is NOT upgraded to '
-                                            'next version. Now its {}'.format(
-                                                upgraded))
-                                else:
-                                    logger.highlight(
-                                        'Unable to fetch previous version but '
-                                        'after upgrade capsule is {}.'.format(
-                                            upgraded))
-                                # Generate foreman debug on capsule postupgrade
-                                execute(
-                                    foreman_debug,
-                                    'capsule_{}'.format(cap_host),
-                                    host=cap_host)
-                            # Execute tasks as post upgrade tier1 tests
-                            # are dependent
-                            if product == 'longrun':
-                                post_upgrade_test_tasks(sat_host, cap_host)
-                        except Exception:
-                            # Generate foreman debug on failed capsule upgrade
-                            execute(
-                                foreman_debug, 'capsule_{}'.format(cap_host),
-                                host=cap_host)
-                            raise
-                if product == 'client' or product == 'longrun':
-                    clients6 = setup_dict['clients6']
-                    clients7 = setup_dict['clients7']
-                    puppet_clients7 = setup_dict['puppet_clients7']
-                    puppet_clients6 = setup_dict['puppet_clients6']
-                    satellite6_client_upgrade('rhel6', clients6)
-                    satellite6_client_upgrade('rhel7', clients7)
-                    satellite6_client_upgrade(
-                        'rhel7', puppet_clients7, puppet=True)
-                    satellite6_client_upgrade(
-                        'rhel6', puppet_clients6, puppet=True)
+                check_upgrade_compatibility(upgrade_type, current, upgraded)
+                execute(foreman_debug, 'satellite_{sat_host}', host=sat_host)
         except Exception:
-            # Generate foreman debug on failed satellite upgrade
-            execute(foreman_debug, 'satellite_{}'.format(sat_host),
-                    host=sat_host)
+            execute(foreman_debug, 'satellite_{}'.format(sat_host), host=sat_host)
             raise
+
+    def product_upgrade_capsule(cap_host):
+        try:
+            with LogAnalyzer(cap_host):
+                current = execute(get_sat_cap_version, 'cap', host=cap_host)[cap_host]
+                if FROM_VERSION != TO_VERSION:
+                    execute(satellite6_capsule_upgrade,
+                            cap_host, sat_host, host=cap_host)
+                elif FROM_VERSION == TO_VERSION:
+                    execute(satellite6_capsule_zstream_upgrade,
+                            cap_host, host=cap_host)
+                upgraded = execute(
+                    get_sat_cap_version, 'cap', host=cap_host)[cap_host]
+                check_upgrade_compatibility(upgrade_type, current, upgraded)
+                # Generate foreman debug on capsule postupgrade
+                execute(foreman_debug, 'capsule_{}'.format(cap_host), host=cap_host)
+                # Execute tasks as post upgrade tier1 tests
+                # are dependent
+            if product == 'longrun':
+                post_upgrade_test_tasks(sat_host, cap_host)
+        except Exception:
+            execute(foreman_debug, f'capsule_{cap_host}', host=cap_host)
+            raise
+
+    def product_upgrade_client():
+        clients6 = setup_dict['clients6']
+        clients7 = setup_dict['clients7']
+        puppet_clients7 = setup_dict['puppet_clients7']
+        puppet_clients6 = setup_dict['puppet_clients6']
+        satellite6_client_upgrade('rhel6', clients6)
+        satellite6_client_upgrade('rhel7', clients7)
+        satellite6_client_upgrade(
+            'rhel7', puppet_clients7, puppet=True)
+        satellite6_client_upgrade(
+            'rhel6', puppet_clients6, puppet=True)
+
+    env.disable_known_hosts = True
+    check_necessary_env_variables_for_upgrade(product)
+    logger.info(f'Performing UPGRADE FROM {FROM_VERSION} TO {TO_VERSION}')
+    # Get the setup dict returned by setup_products_for_upgrade
+    setup_dict = get_setup_data()
+    sat_host = setup_dict['sat_host']
+    cap_hosts = setup_dict['capsule_hosts']
+    pre_upgrade_system_checks(cap_hosts)
+    env['satellite_host'] = sat_host
+
+    if upgrade_type == "satellite":
+        product_upgrade_satellite(sat_host)
+    elif (product == 'capsule' or product == 'longrun' or product == 'client' )\
+            and upgrade_type == 'capsule':
+        for cap_host in cap_hosts:
+            product_upgrade_capsule(cap_host)
+    elif (product == 'client' or product == 'longrun') and upgrade_type == 'client':
+        product_upgrade_client()
+
+
+def check_upgrade_compatibility(upgrade_type, base_version, target_version):
+    """
+    Use to check the setup is compatible with the selected version or not.
+    :param upgrade_type: Upgrade type could be satellite, capsule.
+    :param base_version: base version of the satellite, capsule.
+    :param target_version: target version of the satellite or capsule.
+    """
+    if base_version:
+        if LooseVersion(target_version) > LooseVersion(base_version):
+            logger.highlight(f'The {upgrade_type} is upgraded from {base_version}'
+                             f' to {target_version}')
+        else:
+            logger.highlight(
+                f'The {upgrade_type} is NOT upgraded to next version. Now its {target_version}')
+    else:
+        logger.highlight(
+            f'Unable to fetch previous version from {upgrade_type} but after upgrade capsule'
+            f' is {target_version}.')

--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -29,6 +29,21 @@ from upgrade.helpers.tools import reboot
 logger = logger()
 
 
+def satellite_setup(satellite_host):
+    """
+    The purpose of this method to make the satellite ready for upgrade.
+    :param satellite_host:
+    :return: satellite_host
+    """
+    execute(host_ssh_availability_check, satellite_host)
+    execute(install_prerequisites, host=satellite_host)
+    execute(subscribe, host=satellite_host)
+    execute(foreman_service_restart, host=satellite_host)
+    env['satellite_host'] = satellite_host
+    logger.info(f'Satellite {satellite_host} is ready for Upgrade!')
+    return satellite_host
+
+
 def satellite6_setup(os_version):
     """Sets up required things on upgrade running machine and on Satellite to
     perform satellite upgrade later


### PR DESCRIPTION
In this PR,  We have added a few supports to reduce the complexity of the upgrade.

- Break down the single upgrade fab tasks into three tasks, satellite, capsule, and content host.
- Created a common environment variable file
- Created a common custom repos file.

Apart from that added the Upgrade support for the broker's deployed satellite and capsule, If we have more than one capsule for the upgrade then we need to pass them using a semicolon.