### PR TITLE
[github action] unavailable repos fix

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
+            sudo apt-get update --fix-missing
             sudo apt-get install -y libgnutls28-dev libcurl4-openssl-dev libssl-dev
             pip install -r requirements.txt -r requirements-optional.txt
 


### PR DESCRIPTION
GitHub checks get failed due to some unavailable repos, to fix this we need to update the missing repos. 

```
Err:3 http://security.ubuntu.com/ubuntu focal-updates/main amd64 libunbound8 amd64 1.9.4-2ubuntu1.1
  404  Not Found [IP: 52.154.174.208 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/u/unbound/libunbound8_1.9.4-2ubuntu1.1_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
Fetched 2773 kB in 0s (17.7 MB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```