### PR TITLE
Updated 6.9.z nailgun branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jinja2==2.11.3
 # Get automation-tools from master
 git+https://github.com/SatelliteQE/automation-tools@master#egg=automation-tools
 
-# Get nailgun from master
-git+https://github.com/SatelliteQE/nailgun.git@master#egg=nailgun
+# Get nailgun from 6.9.z
+git+https://github.com/SatelliteQE/nailgun.git@6.9.z#egg=nailgun
 
 --editable .


### PR DESCRIPTION
In the 6.9.z upgrade, the nailgun API is breaking due to the recent changes made in the Repository's entity module https://github.com/SatelliteQE/nailgun/pull/797 , The added ansible parameter's in the Repository module does not exist in the 6.9.z satellite. so we have decided to use the nailgun in the upgrade as per the upgrade branch instead of the master.

**Error:**
```
01:32:25      tools_repo = entities.Repository(
01:32:25    File "/opt/app-root/lib64/python3.8/site-packages/nailgun/entity_mixins.py", line 943, in create
01:32:25      return self.read(attrs=self.create_json(create_missing))
01:32:25    File "/opt/app-root/lib64/python3.8/site-packages/nailgun/entities.py", line 6258, in read
01:32:25      return super().read(entity, attrs, ignore, params)
01:32:25    File "/opt/app-root/lib64/python3.8/site-packages/nailgun/entity_mixins.py", line 806, in read
01:32:25      setattr(entity, field_name, attrs[field_name])
01:32:25  KeyError: 'ansible_collection_auth_url'
```