### PR TITLE
[6.10.z] Avoid running pulp3 migration for 6.10 zstream upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Version updates managed by pyup.io
 
 dynaconf==3.1.7
-broker==0.1.33
+broker==0.1.35
 jinja2==3.0.3
 
 # Get automation-tools from master

--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -131,10 +131,7 @@ def satellite_upgrade(zstream=False):
             )
         foreman_maintain_package_update()
 
-    if bz_bug_is_open(1995650) and settings.upgrade.to_version == '6.10':
-        run("yum remove -y rubygem-passenger")
-
-    if settings.upgrade.to_version == '6.10':
+    if settings.upgrade.from_version == '6.9':
         # To fix the memory related issues for BZ#1989378
         post_migration_failure_fix(100001)
         pulp_migration_status = pulp2_pulp3_migration()


### PR DESCRIPTION
Cherrypicks https://github.com/SatelliteQE/satellite6-upgrade/pull/527