### PR TITLE
[6.9.z] Rename a setting to rhel_os_repo_host

### DIFF
--- a/conf/repos.yaml
+++ b/conf/repos.yaml
@@ -3,10 +3,10 @@ REPOS:
   SATELLITE_VERSION_UNDR: "@jinja {{this.robottelo.satellite_version | replace('.', '_')}}"
   # RHEL major version
   RHEL_MAJOR_VERSION: "@jinja {{this.server.version.rhel_version | int}}"
-  # Next repos tag for the maintenance repos
-  NEXT_MAINTENANCE_REPOS_TAG: '@jinja {{"_Next" if this.robottelo.satellite_version == "6.10" else ""}}'
+  # Set maintenance repos tag to distinguish the old and new maintenance repos structure
+  MAINTENANCE_REPOS_TAG: '@jinja {{"Satellite_Maintenance_Composes/Satellite_Maintenance_RHEL" + this.repos.rhel_major_version if this.robottelo.satellite_version in ["6.9", "6.10"] else "Satellite_Maintenance_" + this.repos.satellite_version_undr + "_Composes/Satellite_Maintenance_" + this.repos.satellite_version_undr + "_RHEL" + this.repos.rhel_major_version }}'
   # RHEL 6,7 and 8 repos for RHAI, OSCAP etc
-  RHEL_REPO_HOST:
+  RHEL_OS_REPO_HOST:
   # Capsule repository
   CAPSULE_REPO:
   # rhel6 custom repo

--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -907,7 +907,7 @@ def post_upgrade_test_tasks(sat_host, cap_host=None):
     # logger.info("Removing the Original Manifest from Default Organization")
     # execute(hammer, 'subscription delete-manifest --organization-id 1',
     #         host=sat_host)
-    os.environ['HTTP_SERVER_HOSTNAME'] = settings.repos.rhel_repo_host
+    os.environ['HTTP_SERVER_HOSTNAME'] = settings.repos.rhel_os_repo_host
     # Run Avahi Task on upgrade boxes for REX tests to run
     execute(foreman_packages_installation_check, state="unlock", non_upgrade_task=True,
             host=sat_host)

--- a/upgrade/runner.py
+++ b/upgrade/runner.py
@@ -4,10 +4,10 @@ Many commands are affected by environment variables. Unless stated otherwise,
 all environment variables are required.
 """
 import sys
-from distutils.version import LooseVersion
 
 from automation_tools import foreman_debug
 from automation_tools.satellite6.log import LogAnalyzer
+from distutils.version import LooseVersion
 from fabric.api import env
 from fabric.api import execute
 


### PR DESCRIPTION
Unify setting name in all branches - this time for `6.9.z`