### PR TITLE
Fix capsule features compare test

### DIFF
--- a/upgrade_tests/test_existance_relations/cli/test_capsules.py
+++ b/upgrade_tests/test_existance_relations/cli/test_capsules.py
@@ -43,7 +43,11 @@ def test_positive_capsules_by_features(pre, post):
     :expectedresults: All features of all capsules should be retained post
         upgrade
     """
-    assert existence(pre, post, component)
+    assert existence(
+        list(map(str.strip, pre.split(','))),
+        list(map(str.strip, post.split(','))),
+        component
+    )
 
 
 @pytest.mark.parametrize("pre,post", cap_name, ids=pytest_ids(cap_name))


### PR DESCRIPTION
Fixes:
```
pre = 'registration, discovery, pulpcore, templates, openscap, tftp, dynflow, ssh, puppet ca, puppet, ansible'
post = 'registration, discovery, templates, openscap, tftp, dynflow, ssh, puppet ca, puppet, ansible, pulpcore'

    @dont_run_to_upgrade('6.1')
    @pytest.mark.parametrize(
        "pre,post", cap_features, ids=pytest_ids(cap_features))
    def test_positive_capsules_by_features(pre, post):
        """Test all features of each capsule are existing post upgrade
    
        :id: upgrade-6d3b8f24-2d51-465c-8d01-5a159aa89f2f
    
        :expectedresults: All features of all capsules should be retained post
            upgrade
        """
>       assert existence(pre, post, component)
E       AssertionError: assert False
E        +  where False = existence('registration, discovery, pulpcore, templates, openscap, tftp, dynflow, ssh, puppet ca, puppet, ansible', 'registration, discovery, templates, openscap, tftp, dynflow, ssh, puppet ca, puppet, ansible, pulpcore', 'capsule')

upgrade_tests/test_existance_relations/cli/test_capsules.py:46: AssertionError
```

Better way would be to fix this in fixture (get and store capsule features as list not string)
Would you @jyejare pls point me out where to do it? Or is my solution OK?