### PR TITLE
Remove nonfm upgrade task and settings

### DIFF
--- a/conf/upgrade.yaml.template
+++ b/conf/upgrade.yaml.template
@@ -30,8 +30,6 @@ UPGRADE:
     - "n-1"
   # Upgrade codebase select the repository based on the distribution.
   DISTRIBUTION: "downstream"
-  # By default Satellite upgrade perform by foreman-maintain.
-  FOREMAN_MAINTAIN_SATELLITE_UPGRADE: true
   # Satellite hostname.
   SATELLITE_HOSTNAME:
   # capsule hostname
@@ -40,8 +38,6 @@ UPGRADE:
   DOWNSTREAM_FM_UPGRADE: false
   # Used to whitelist the mentioned params in the foreman-maintain upgrade.
   WHITELIST_PARAM: ""
-  # Capsule upgrade via foreman-maintain, due to limited version support, we keep it as false.
-  FOREMAN_MAINTAIN_CAPSULE_UPGRADE: false
   # User Defined clients, we use it for content host upgrade.
   USER_DEFINED_CLIENT_HOSTS:
     RHEL6:

--- a/upgrade/capsule.py
+++ b/upgrade/capsule.py
@@ -16,7 +16,6 @@ from upgrade.helpers.tasks import enable_disable_repo
 from upgrade.helpers.tasks import foreman_maintain_package_update
 from upgrade.helpers.tasks import foreman_service_restart
 from upgrade.helpers.tasks import http_proxy_config
-from upgrade.helpers.tasks import nonfm_upgrade
 from upgrade.helpers.tasks import sync_capsule_repos_to_satellite
 from upgrade.helpers.tasks import update_capsules_to_satellite
 from upgrade.helpers.tasks import upgrade_using_foreman_maintain
@@ -134,16 +133,11 @@ def satellite_capsule_upgrade(cap_host, sat_host):
         enable_disable_repo(enable_repos_name=[
             f"rhel-{major_ver}-server-ansible-2.9-rpms"])
 
-    if settings.upgrade.foreman_maintain_capsule_upgrade:
-        foreman_maintain_package_update()
-        if settings.upgrade.from_version == '6.10':
-            # capsule certs regeneration required prior 6.11 ystream capsule upgrade BZ#2049893
-            execute(capsule_certs_update, cap_host, host=sat_host)
-        upgrade_using_foreman_maintain(sat_host=False)
-    else:
-        nonfm_upgrade(satellite_upgrade=False,
-                      cap_host=cap_host,
-                      sat_host=sat_host)
+    foreman_maintain_package_update()
+    if settings.upgrade.from_version == '6.10':
+        # capsule certs regeneration required prior 6.11 ystream capsule upgrade BZ#2049893
+        execute(capsule_certs_update, cap_host, host=sat_host)
+    upgrade_using_foreman_maintain(sat_host=False)
     # Rebooting the capsule for kernel update if any
     reboot(160)
     host_ssh_availability_check(cap_host)
@@ -195,10 +189,7 @@ def satellite_capsule_zstream_upgrade(cap_host):
         enable_disable_repo(enable_repos_name=ansible_repos)
     # Check what repos are set
     # setup_foreman_maintain_repo()
-    if settings.upgrade.foreman_maintain_capsule_upgrade:
-        upgrade_using_foreman_maintain(sat_host=False)
-    else:
-        nonfm_upgrade(satellite_upgrade=False)
+    upgrade_using_foreman_maintain(sat_host=False)
     # Rebooting the capsule for kernel update if any
     if settings.upgrade.satellite_capsule_setup_reboot:
         reboot(160)

--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -12,14 +12,12 @@ from random import randrange
 
 import requests
 from automation_tools import setup_alternate_capsule_ports
-from automation_tools import setup_capsule_firewall
 from automation_tools import setup_fake_manifest_certificate
 from automation_tools import setup_foreman_discovery
 from automation_tools.repository import disable_repos
 from automation_tools.repository import enable_repos
 from automation_tools.satellite6.capsule import generate_capsule_certs
 from automation_tools.utils import get_discovery_image
-from automation_tools.utils import update_packages
 from fabric import exceptions
 from fabric.api import env
 from fabric.api import execute
@@ -1707,55 +1705,6 @@ def enable_disable_repo(disable_repos_name=None, enable_repos_name=None):
         [enable_repos(f'{repo}') for repo in enable_repos_name]
 
 
-def nonfm_upgrade(satellite_upgrade=True,
-                  cap_host=None, sat_host=None):
-    """
-    The purpose of this module to perform the upgrade task without foreman-maintain.
-    In this function we setup the repository, stop the foreman-maintain services,
-    cleanup, and execute satellite upgrade task"
-    :param bool satellite_upgrade: If satellite_upgrade is True then upgrade
-    type satellite otherwise capsule
-    :param bool zstream: Capsule zStream upgrade
-    :param str cap_host: hostname of capsule it used to generate certificate for
-    capsules major version upgrade.
-    :param str sat_host: hostname of satellite used to generate certificate for
-    capsules major version upgrade.
-    :
-    """
-    # Check what repos are set
-    upgrade_type = "satellite" if satellite_upgrade else "capsule"
-    run('yum repolist')
-    # Stop foreman-maintain services
-    run('foreman-maintain service stop')
-    run('yum clean all', warn_only=True)
-    # Updating the packages again after setting sat repo
-    logger.info(f'Updating system and {upgrade_type} packages... ')
-    preyum_time = datetime.now().replace(microsecond=0)
-    update_packages(quiet=False)
-    postyum_time = datetime.now().replace(microsecond=0)
-    logger.highlight(f'Time taken for system and {upgrade_type} packages update'
-                     f' - {str(postyum_time - preyum_time)}')
-    # non zStream capsule upgrade
-    if sat_host and cap_host:
-        execute(
-            generate_capsule_certs,
-            cap_host,
-            True,
-            host=sat_host
-        )
-        execute(lambda: run(f"scp -o 'StrictHostKeyChecking no' {cap_host}-certs.tar "
-                            f"root@{cap_host}:/home/"), host=sat_host)
-        setup_capsule_firewall()
-        preup_time = datetime.now().replace(microsecond=0)
-        upgrade_task(upgrade_type, cap_host)
-    else:
-        preup_time = datetime.now().replace(microsecond=0)
-        upgrade_task(upgrade_type)
-    postup_time = datetime.now().replace(microsecond=0)
-    logger.highlight('Time taken for satellite upgrade - {}'.format(
-        str(postup_time - preup_time)))
-
-
 def upgrade_task(upgrade_type, cap_host=None):
     """
     :param string upgrade_type: upgrade type would be an string either it is
@@ -1860,24 +1809,6 @@ def mongo_db_engine_upgrade(upgrade_type="satellite"):
     logger.info("MongoDB DataBase Engine Upgraded Successfully")
     logger.highlight('Time taken by MongoDB DataBase Engine Upgrade - {}'.format(
         str(postup_time - preup_time)))
-
-
-def foreman_packages_installation_check(state="unlock", non_upgrade_task=False):
-    """
-    This function is used to change the state of the foreman-package installation method,
-    And it will be applicable only if the FOREMAN_MAINTAIN_SATELLITE_UPGRADE is False.
-
-    :param str state: To perform the installation using foreman-maintain the state will be
-    "lock" otherwise "unlock"
-    :param bool non_upgrade_task: to unlock the packages for non_upgrade_task
-
-    """
-    if not settings.upgrade.foreman_maintain_satellite_upgrade or non_upgrade_task:
-        logger.info("{} the foreman-maintain packages".format(state))
-        run("foreman-maintain packages {} -y".format(state))
-    else:
-        logger.info("Failed to apply the {} state on foreman-maintain packages , "
-                    "because FOREMAN_MAINTAIN_SATELLITE_UPGRADE is true")
 
 
 def job_execution_time(task_name, start_time=None):

--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -1,11 +1,8 @@
 import sys
 
 from automation_tools import install_prerequisites
-from automation_tools import setup_satellite_firewall
-from automation_tools.utils import update_packages
 from fabric.api import env
 from fabric.api import execute
-from fabric.api import run
 
 from upgrade.helpers import settings
 from upgrade.helpers.constants.constants import CUSTOM_SAT_REPO
@@ -13,17 +10,14 @@ from upgrade.helpers.constants.constants import RHEL_CONTENTS
 from upgrade.helpers.logger import logger
 from upgrade.helpers.tasks import enable_disable_repo
 from upgrade.helpers.tasks import foreman_maintain_package_update
-from upgrade.helpers.tasks import foreman_packages_installation_check
 from upgrade.helpers.tasks import foreman_service_restart
 from upgrade.helpers.tasks import hammer_config
 from upgrade.helpers.tasks import maintenance_repo_update
 from upgrade.helpers.tasks import mongo_db_engine_upgrade
-from upgrade.helpers.tasks import nonfm_upgrade
 from upgrade.helpers.tasks import post_migration_failure_fix
 from upgrade.helpers.tasks import pulp2_pulp3_migration
 from upgrade.helpers.tasks import repository_setup
 from upgrade.helpers.tasks import satellite_backup
-from upgrade.helpers.tasks import setup_satellite_repo
 from upgrade.helpers.tasks import subscribe
 from upgrade.helpers.tasks import upgrade_using_foreman_maintain
 from upgrade.helpers.tasks import upgrade_validation
@@ -74,8 +68,6 @@ def satellite_upgrade(zstream=False):
             TO_VERSION
                 Satellite version to upgrade to and enable repos while upgrading.
                 e.g '6.1','6.2', '6.3'
-            FOREMAN_MAINTAIN_SATELLITE_UPGRADE
-                use foreman-maintain for satellite upgrade
 
     else:
         - Upgrades Satellite Server to its latest zStream version
@@ -85,8 +77,6 @@ def satellite_upgrade(zstream=False):
                 Current satellite version which will be upgraded to latest version
             TO_VERSION
                 Next satellite version to which satellite will be upgraded
-            FOREMAN_MAINTAIN_SATELLITE_UPGRADE
-                use foreman-maintain for satellite upgrade
 
     """
     logger.highlight('\n========== SATELLITE UPGRADE =================\n')
@@ -110,10 +100,6 @@ def satellite_upgrade(zstream=False):
     # maintenance repository update for satellite upgrade
     maintenance_repo_update()
 
-    # It is required to enable the tools and server for non-fm upgrade because in
-    # fm both the repos enabled by the fm tool.
-    if not settings.upgrade.foreman_maintain_satellite_upgrade:
-        enable_disable_repo(enable_repos_name=common_sat_cap_repos)
     if settings.upgrade.distribution == 'cdn':
         enable_disable_repo(
             enable_repos_name=[f'rhel-{major_ver}-server-satellite-maintenance-6-rpms']
@@ -141,25 +127,8 @@ def satellite_upgrade(zstream=False):
         if not pulp_migration_status:
             logger.highlight("Pulp migration failed. Aborting")
             sys.exit(1)
-    if settings.upgrade.foreman_maintain_satellite_upgrade:
-        upgrade_using_foreman_maintain()
-    else:
-        # To install the package using foreman-maintain and it is applicable
-        # above 6.7 version.
-        setup_satellite_firewall()
-        if not zstream:
-            run('rm -rf /etc/yum.repos.d/rhel-{optional,released}.repo')
-            logger.info('Updating system packages ... ')
-            foreman_packages_installation_check(state="unlock")
-            setup_satellite_repo()
-            foreman_maintain_package_update()
-            update_packages(quiet=True)
+    upgrade_using_foreman_maintain()
 
-        if settings.upgrade.distribution == "cdn":
-            enable_disable_repo(enable_repos_name=[f'rhel-{major_ver}-server-satellite'
-                                                   f'-{settings.upgrade.to_version}-rpms'])
-        nonfm_upgrade()
-        foreman_packages_installation_check(state="lock")
     # Rebooting the satellite for kernel update if any
     if settings.upgrade.satellite_capsule_setup_reboot:
         reboot(180)


### PR DESCRIPTION
### Problem
- foreman-maintain is mandatory for performing upgrades now. There is no other official way how to upgrade the product.

### Solution
- remove the code performing upgrade w/o foreman-maintain - `nonfm_upgrade` task
- remove relevant settings `settings.upgrade.foreman_maintain_satellite_upgrade` and `settings.upgrade.foreman_maintain_capsule_upgrade`

### Tests
see `SAT-11335` for test results