### PR TITLE
[6.11.z] Fix satellite_backup() using removed setting

### DIFF
--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -1361,8 +1361,7 @@ def satellite_backup():
     preyum_time = datetime.now().replace(microsecond=0)
     with fabric_settings(warn_only=True):
         output = run(f"satellite-maintain backup {satellite_backup_type} "
-                     f"--skip-pulp-content -y {settings.clone.backup_dir}"
-                     f"_{satellite_backup_type}")
+                     f"--skip-pulp-content -y /tmp")
         postyum_time = datetime.now().replace(microsecond=0)
         logger.highlight(f'Time taken by {satellite_backup_type} satellite backup - '
                          f'{str(postyum_time - preyum_time)}')


### PR DESCRIPTION
Cherrypicks #556 to `6.11.z`

(cherry picked from commit 277caf96a444f6f5f32c971e27c49b9748ef3b53)