### PR TITLE
Fix CLI test_positive_capsules_by_features

### DIFF
--- a/upgrade_tests/test_existance_relations/cli/test_capsules.py
+++ b/upgrade_tests/test_existance_relations/cli/test_capsules.py
@@ -42,8 +42,8 @@ def test_positive_capsules_by_features(pre, post):
         upgrade
     """
     assert existence(
-        list(map(str.strip, pre.split(','))),
-        list(map(str.strip, post.split(','))),
+        set(map(str.strip, pre.split(','))),
+        set(map(str.strip, post.split(','))),
         component
     )
 


### PR DESCRIPTION
Fix in #543 was not right by using lists to compare. 
Instead I should've used sets for comparison