### PR TITLE
[6.11.z] Fix CLI test_positive_capsules_by_features

### DIFF
--- a/upgrade_tests/test_existance_relations/cli/test_capsules.py
+++ b/upgrade_tests/test_existance_relations/cli/test_capsules.py
@@ -42,8 +42,8 @@ def test_positive_capsules_by_features(pre, post):
         upgrade
     """
     assert existence(
-        list(map(str.strip, pre.split(','))),
-        list(map(str.strip, post.split(','))),
+        set(map(str.strip, pre.split(','))),
+        set(map(str.strip, post.split(','))),
         component
     )
 


### PR DESCRIPTION
Cherrypicks #562 to `6.11.z`

(cherry picked from commit fcdff6c894be534830fd98954994259aea4f93fa)