### PR TITLE
[6.11.z] Revert "Pin hvac<1.0.0"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     install_requires=[
         'broker',
         'dynaconf[vault]',
-        'hvac<1.0.0',
         'Fabric3',
         'fauxfactory',
         'jinja2',


### PR DESCRIPTION
Reverts SatelliteQE/satellite6-upgrade#560 as dynaconf issue is fixed now
And new https://github.com/dynaconf/dynaconf/releases/tag/3.1.11 is released
