### PR TITLE
[6.11.z] Remove downstream_fm_upgrade setting

### DIFF
--- a/conf/upgrade.yaml.template
+++ b/conf/upgrade.yaml.template
@@ -34,8 +34,6 @@ UPGRADE:
   SATELLITE_HOSTNAME:
   # capsule hostname
   CAPSULE_HOSTNAME:
-  # This statement will true until downstream release not become beta.
-  DOWNSTREAM_FM_UPGRADE: false
   # Used to whitelist the mentioned params in the foreman-maintain upgrade.
   WHITELIST_PARAM: ""
   # User Defined clients, we use it for content host upgrade.

--- a/upgrade/runner.py
+++ b/upgrade/runner.py
@@ -15,7 +15,6 @@ from upgrade.client import satellite6_client_upgrade
 from upgrade.helpers import settings
 from upgrade.helpers.logger import logger
 from upgrade.helpers.tasks import check_settings_for_upgrade
-from upgrade.helpers.tasks import maintenance_repo_update
 from upgrade.helpers.tasks import post_upgrade_test_tasks
 from upgrade.helpers.tasks import pre_upgrade_system_checks
 from upgrade.helpers.tasks import satellite_restore
@@ -89,7 +88,6 @@ def product_setup_for_db_upgrade(satellite):
     settings.upgrade.satellite_hostname = satellite
     execute(unsubscribe, host=satellite)
     execute(subscribe, host=satellite)
-    maintenance_repo_update()
     execute(setup_foreman_maintain_repo, host=satellite)
     execute(satellite_restore_setup, host=satellite)
     execute(satellite_restore, host=satellite)

--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -12,7 +12,6 @@ from upgrade.helpers.logger import logger
 from upgrade.helpers.tasks import enable_disable_repo
 from upgrade.helpers.tasks import foreman_maintain_package_update
 from upgrade.helpers.tasks import hammer_config
-from upgrade.helpers.tasks import maintenance_repo_update
 from upgrade.helpers.tasks import repository_setup
 from upgrade.helpers.tasks import satellite_backup
 from upgrade.helpers.tasks import subscribe
@@ -34,7 +33,6 @@ def satellite_setup(satellite_host):
     execute(host_ssh_availability_check, satellite_host)
     execute(yum_repos_cleanup, host=satellite_host)
     execute(subscribe, host=satellite_host)
-    maintenance_repo_update()
     env['satellite_host'] = satellite_host
     settings.upgrade.satellite_hostname = satellite_host
     execute(hammer_config, host=satellite_host)
@@ -58,10 +56,8 @@ def satellite_upgrade(zstream=False):
     enable_disable_repo(disable_repos_name=['*'])
     enable_disable_repo(enable_repos_name=[repo['label'] for repo in OS_REPOS.values()])
 
-    if settings.upgrade.downstream_fm_upgrade or settings.upgrade.to_version == '6.12':
+    if settings.upgrade.distribution != 'cdn':
         settings.upgrade.whitelist_param = ', repositories-validate, repositories-setup'
-    # maintenance repository update for satellite upgrade
-    maintenance_repo_update()
 
     if settings.upgrade.distribution == 'cdn':
         enable_disable_repo(enable_repos_name=[RH_CONTENT['maintenance']['label']])


### PR DESCRIPTION
Cherrypicks #558 to `6.11.z`

(cherry picked from commit 038423404c0bb5f0dc702027528321a856a80160)