### PR TITLE
[6.11.z] Perform backup in plaintext output mode

### DIFF
--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -1342,7 +1342,7 @@ def satellite_backup():
     preyum_time = datetime.now().replace(microsecond=0)
     with fabric_settings(warn_only=True):
         output = run(f"satellite-maintain backup {satellite_backup_type} "
-                     f"--skip-pulp-content -y /tmp")
+                     f"--plaintext --skip-pulp-content -y /tmp")
         postyum_time = datetime.now().replace(microsecond=0)
         logger.highlight(f'Time taken by {satellite_backup_type} satellite backup - '
                          f'{str(postyum_time - preyum_time)}')


### PR DESCRIPTION
Cherrypicks #574 to `6.11.z`

(cherry picked from commit 8abb335a84046e5ddc9589040d2773d52489e38f)