### PR TITLE
[6.10.z] Remove downstream_fm_upgrade setting

### DIFF
--- a/conf/upgrade.yaml.template
+++ b/conf/upgrade.yaml.template
@@ -34,8 +34,6 @@ UPGRADE:
   SATELLITE_HOSTNAME:
   # capsule hostname
   CAPSULE_HOSTNAME:
-  # This statement will true until downstream release not become beta.
-  DOWNSTREAM_FM_UPGRADE: false
   # Used to whitelist the mentioned params in the foreman-maintain upgrade.
   WHITELIST_PARAM: ""
   # User Defined clients, we use it for content host upgrade.

--- a/upgrade/runner.py
+++ b/upgrade/runner.py
@@ -19,7 +19,6 @@ from upgrade.client import satellite6_client_upgrade
 from upgrade.helpers import settings
 from upgrade.helpers.logger import logger
 from upgrade.helpers.tasks import check_necessary_env_variables_for_upgrade
-from upgrade.helpers.tasks import maintenance_repo_update
 from upgrade.helpers.tasks import post_upgrade_test_tasks
 from upgrade.helpers.tasks import pre_upgrade_system_checks
 from upgrade.helpers.tasks import satellite_restore
@@ -93,7 +92,6 @@ def product_setup_for_db_upgrade(satellite):
     settings.upgrade.satellite_hostname = satellite
     execute(unsubscribe, host=satellite)
     execute(subscribe, host=satellite)
-    maintenance_repo_update()
     execute(setup_foreman_maintain_repo, host=satellite)
     execute(satellite_restore_setup, host=satellite)
     execute(satellite_restore, host=satellite)

--- a/upgrade/satellite.py
+++ b/upgrade/satellite.py
@@ -12,7 +12,6 @@ from upgrade.helpers.tasks import enable_disable_repo
 from upgrade.helpers.tasks import foreman_maintain_package_update
 from upgrade.helpers.tasks import foreman_service_restart
 from upgrade.helpers.tasks import hammer_config
-from upgrade.helpers.tasks import maintenance_repo_update
 from upgrade.helpers.tasks import mongo_db_engine_upgrade
 from upgrade.helpers.tasks import post_migration_failure_fix
 from upgrade.helpers.tasks import pulp2_pulp3_migration
@@ -40,7 +39,6 @@ def satellite_setup(satellite_host):
     execute(install_prerequisites, host=satellite_host)
     execute(subscribe, host=satellite_host)
     execute(foreman_service_restart, host=satellite_host)
-    maintenance_repo_update()
     env['satellite_host'] = satellite_host
     settings.upgrade.satellite_hostname = satellite_host
     execute(hammer_config, host=satellite_host)
@@ -94,12 +92,9 @@ def satellite_upgrade(zstream=False):
     # disable all the repos
     enable_disable_repo(disable_repos_name=["*"])
 
-    if settings.upgrade.downstream_fm_upgrade:
+    if settings.upgrade.distribution != 'cdn':
         settings.upgrade.whitelist_param = ", repositories-validate, repositories-setup"
         enable_disable_repo(enable_repos_name=common_sat_cap_repos)
-
-    # maintenance repository update for satellite upgrade
-    maintenance_repo_update()
 
     if settings.upgrade.distribution == 'cdn':
         enable_disable_repo(


### PR DESCRIPTION
Cherrypicks #558 to `6.10.z`

(cherry picked from commit 038423404c0bb5f0dc702027528321a856a80160)