### PR TITLE
[6.11.z] Use Fabric3 customized for py3.10 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,7 @@ git+https://github.com/SatelliteQE/automation-tools@master#egg=automation-tools
 # Get nailgun from master
 git+https://github.com/SatelliteQE/nailgun.git@master#egg=nailgun
 
+# Once https://github.com/mathiasertl/fabric/pull/57 gets merged put 'Fabric3' in setup.py
+git+https://github.com/wmorgan6796/fabric.git@add_python3.10_compat#egg=Fabric3
+
 --editable .

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     install_requires=[
         'broker',
         'dynaconf[vault]',
-        'Fabric3',
         'fauxfactory',
         'jinja2',
         'ovirt-engine-sdk-python',


### PR DESCRIPTION
Cherrypicks #595 to `6.11.z` branch
(cherry picked from commit df8c1b803ccd1bf943cabf598798ccafe6ea3a3b)