### PR TITLE
Use original Fabric 1.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,4 @@ git+https://github.com/SatelliteQE/automation-tools@master#egg=automation-tools
 # Get nailgun from master
 git+https://github.com/SatelliteQE/nailgun.git@master#egg=nailgun
 
-# Once https://github.com/mathiasertl/fabric/pull/57 gets merged put 'Fabric3' in setup.py
-git+https://github.com/wmorgan6796/fabric.git@add_python3.10_compat#egg=Fabric3
-
 --editable .

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=[
         'broker',
         'dynaconf[vault]',
+        'fabric<2',
         'fauxfactory',
         'jinja2',
         'ovirt-engine-sdk-python',


### PR DESCRIPTION
Finally old Fabric 1.x is python3 compatible.
By https://github.com/fabric/fabric/tree/1.15.0 released on 2022-04-07

 _Merge the longstanding fabric3 fork back into our v1 branch so users who’d rather port Fabric 1.x code to Python 3 before upgrading to Fabric 2.x, are able to do so in a “blessed” manner._