### PR TITLE
Enable satellite-maintenance module before cloning

### DIFF
--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -1301,6 +1301,8 @@ def satellite_restore_setup():
         run(f"cd /usr/share; git clone -q {settings.clone.satellite_clone_upstream_repos}")
     else:
         run('yum -d1 repolist')
+        if os_ver > 7:
+            run(f'yum -d1 module enable satellite-maintenance:el{os_ver}')
         run('yum -d1 install -y satellite-clone')
     run(
         f'echo "satellite_version: {settings.upgrade.from_version}">>{answer_file};'


### PR DESCRIPTION
Since 6.13.0 Snap15 `satellite-maintenance:el8` dnf module has been introduced.
In order to get `satellite-clone` installed one has to enable the respective module first.