### PR TITLE
[6.13.z] Enable satellite-maintenance module before cloning

### DIFF
--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -1301,6 +1301,8 @@ def satellite_restore_setup():
         run(f"cd /usr/share; git clone -q {settings.clone.satellite_clone_upstream_repos}")
     else:
         run('yum -d1 repolist')
+        if os_ver > 7:
+            run(f'yum -d1 module enable satellite-maintenance:el{os_ver}')
         run('yum -d1 install -y satellite-clone')
     run(
         f'echo "satellite_version: {settings.upgrade.from_version}">>{answer_file};'


### PR DESCRIPTION
Cherrypicks #617 to `6.13.z`

(cherry picked from commit 2f8ae2853ba5c99bc3711094a8cb314f03776935)