### PR TITLE
Enable repositories gradually during upgrade

### DIFF
--- a/conf/upgrade.yaml.template
+++ b/conf/upgrade.yaml.template
@@ -30,6 +30,8 @@ UPGRADE:
     - "n-1"
   # Upgrade codebase select the repository based on the distribution.
   DISTRIBUTION: "downstream"
+  # Use beta repositories for CDN distribution
+  USE_BETA: false
   # Satellite hostname.
   SATELLITE_HOSTNAME:
   # capsule hostname

--- a/fabfile.py
+++ b/fabfile.py
@@ -5,11 +5,11 @@ from upgrade.helpers.docker import docker_execute_command
 from upgrade.helpers.docker import generate_satellite_docker_clients
 from upgrade.helpers.docker import refresh_subscriptions_on_docker_clients
 from upgrade.helpers.tasks import create_capsule_ak
+from upgrade.helpers.tasks import foreman_maintain_upgrade
 from upgrade.helpers.tasks import generate_custom_certs
 from upgrade.helpers.tasks import job_execution_time
 from upgrade.helpers.tasks import sync_capsule_repos_to_satellite
 from upgrade.helpers.tasks import update_scap_content
-from upgrade.helpers.tasks import upgrade_using_foreman_maintain
 from upgrade.helpers.tools import copy_ssh_key
 from upgrade.helpers.tools import disable_old_repos
 from upgrade.helpers.tools import get_hostname_from_ip

--- a/upgrade/helpers/constants/constants.py
+++ b/upgrade/helpers/constants/constants.py
@@ -132,24 +132,24 @@ CUSTOM_CONTENT = {
 
 
 CUSTOM_SAT_REPO = {
-    "sat": {
-        "repository": "sat",
-        "repository_name": "satellite",
+    "satellite": {
+        "repository": "satellite",
+        "repository_name": "Satellite",
         "base_url": f"{settings.repos.satellite_repo}",
-    },
-    "sattools": {
-        "repository": "sattools",
-        "repository_name": "satellite-tools",
-        "base_url": f"{settings.repos.sattools_repo[settings.upgrade.os]}",
     },
     "maintenance": {
         "repository": "maintenance",
-        "repository_name": "satellite-maintenance",
+        "repository_name": "Satellite Maintenance",
         "base_url": f"{settings.repos.satmaintenance_repo}",
+    },
+    "capsule": {
+        "repository": "capsule",
+        "repository_name": "Capsule",
+        "base_url": f"{settings.repos.capsule_repo}",
     },
     "satclient": {
         "repository": "satclient",
-        "repository_name": "sat-client",
+        "repository_name": "Satellite Client",
         "base_url": f"{settings.repos.satclient_repo[settings.upgrade.os]}",
     },
 }

--- a/upgrade/helpers/constants/constants.py
+++ b/upgrade/helpers/constants/constants.py
@@ -1,39 +1,14 @@
 """Upgrade needed Constants"""
-from packaging.version import Version
-
 from upgrade.helpers import settings
 
 os_ver = int(settings.upgrade.os.strip('rhel'))
 arch = 'x86_64'
-target_cap_version = settings.upgrade.to_version \
+target_version = settings.upgrade.to_version \
     if settings.upgrade.from_version != settings.upgrade.to_version and \
     settings.upgrade.distribution == 'cdn' else settings.upgrade.from_version
-maintenance_ver = target_cap_version if Version(target_cap_version) > Version('6.10') else '6'
-os_repo_tags = ['server', 'rhscl', 'ansible'] if os_ver < 8 else ['baseos', 'appstream']
+os_repo_tags = ['baseos', 'appstream']
 
 RH_CONTENT = {
-    # RHEL7 repos
-    'server': {
-        'prod': 'Red Hat Enterprise Linux Server',
-        'reposet': f'Red Hat Enterprise Linux {os_ver} Server (RPMs)',
-        'repo': f'Red Hat Enterprise Linux {os_ver} Server RPMs {arch} {os_ver}Server',
-        'label': f'rhel-{os_ver}-server-rpms',
-    },
-    'rhscl': {
-        'prod': 'Red Hat Software Collections (for RHEL Server)',
-        'reposet': f'Red Hat Software Collections RPMs for Red Hat Enterprise Linux {os_ver} '
-        'Server',
-        'repo': f'Red Hat Software Collections RPMs for Red Hat Enterprise Linux {os_ver} '
-        f'Server x86_64 {os_ver}Server',
-        'label': f'rhel-server-rhscl-{os_ver}-rpms'
-    },
-    'ansible': {
-        'prod': 'Red Hat Ansible Engine',
-        'reposet': f'Red Hat Ansible Engine 2.9 RPMs for Red Hat Enterprise Linux {os_ver} Server',
-        'repo': f'Red Hat Ansible Engine 2.9 RPMs for Red Hat Enterprise Linux {os_ver} Server '
-        f'{arch}',
-        'label': f'rhel-{os_ver}-server-ansible-2.9-rpms'
-    },
     # RHEL8+ repos
     'baseos': {
         'prod': f'Red Hat Enterprise Linux for {arch}',
@@ -49,51 +24,24 @@ RH_CONTENT = {
     },
     # PRODUCT repos
     'client': {
-        'prod': 'Red Hat Enterprise Linux Server',
-        'reposet': f'Red Hat Satellite Client 6 (for RHEL {os_ver} Server) (RPMs)',
-        'repo': f'Red Hat Satellite Client 6 for RHEL {os_ver} Server RPMs {arch}',
-        'label': f'rhel-{os_ver}-server-satellite-client-6-rpms'
-    } if os_ver < 8 else {
         'prod': f'Red Hat Enterprise Linux for {arch}',
         'reposet': f'Red Hat Satellite Client 6 for RHEL {os_ver} {arch} (RPMs)',
         'repo': f'Red Hat Satellite Client 6 for RHEL {os_ver} {arch} RPMs',
         'label': f'satellite-client-6-for-rhel-{os_ver}-{arch}-rpms'
     },
-    'tools': {
-        'prod': 'Red Hat Enterprise Linux Server',
-        'reposet': f'Red Hat Satellite Tools {target_cap_version} (for RHEL {os_ver} Server) '
-        '(RPMs)',
-        'repo': f'Red Hat Satellite Tools {target_cap_version} for RHEL {os_ver} Server RPMs '
-        f'{arch}',
-        'label': f'rhel-{os_ver}-server-satellite-tools-{target_cap_version}-rpms',
-    },
     'capsule': {
         'prod': 'Red Hat Satellite Capsule',
-        'reposet': f'Red Hat Satellite Capsule {target_cap_version} (for RHEL {os_ver} Server) '
+        'reposet': f'Red Hat Satellite Capsule {target_version} for RHEL {os_ver} {arch} '
         '(RPMs)',
-        'repo': f'Red Hat Satellite Capsule {target_cap_version} for RHEL {os_ver} Server RPMs '
-        f'{arch}',
-        'label': f'rhel-{os_ver}-server-satellite-capsule-{target_cap_version}-rpms'
-    } if os_ver < 8 else {
-        'prod': 'Red Hat Satellite Capsule',
-        'reposet': f'Red Hat Satellite Capsule {target_cap_version} for RHEL {os_ver} {arch} '
-        '(RPMs)',
-        'repo': f'Red Hat Satellite Capsule {target_cap_version} for RHEL {os_ver} {arch} RPMs',
-        'label': f'satellite-capsule-{target_cap_version}-for-rhel-{os_ver}-{arch}-rpms'
+        'repo': f'Red Hat Satellite Capsule {target_version} for RHEL {os_ver} {arch} RPMs',
+        'label': f'satellite-capsule-{target_version}-for-rhel-{os_ver}-{arch}-rpms'
     },
     'maintenance': {
-        'prod': 'Red Hat Enterprise Linux Server',
-        'reposet': f'Red Hat Satellite Maintenance {maintenance_ver} (for RHEL {os_ver} Server) '
-        '(RPMs)',
-        'repo': f'Red Hat Satellite Maintenance {maintenance_ver} for RHEL {os_ver} Server RPMs '
-        f'{arch}',
-        'label': f'rhel-{os_ver}-server-satellite-maintenance-{maintenance_ver}-rpms'
-    } if os_ver < 8 else {
         'prod': f'Red Hat Enterprise Linux for {arch}',
-        'reposet': f'Red Hat Satellite Maintenance {maintenance_ver} for RHEL {os_ver} {arch} '
+        'reposet': f'Red Hat Satellite Maintenance {target_version} for RHEL {os_ver} {arch} '
         '(RPMs)',
-        'repo': f'Red Hat Satellite Maintenance {maintenance_ver} for RHEL {os_ver} {arch} RPMs',
-        'label': f'satellite-maintenance-{maintenance_ver}-for-rhel-{os_ver}-{arch}-rpms'
+        'repo': f'Red Hat Satellite Maintenance {target_version} for RHEL {os_ver} {arch} RPMs',
+        'label': f'satellite-maintenance-{target_version}-for-rhel-{os_ver}-{arch}-rpms'
     },
 }
 

--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -7,6 +7,7 @@ import re
 import socket
 import sys
 import time
+from contextlib import nullcontext
 from datetime import datetime
 from io import StringIO
 from random import randrange
@@ -25,7 +26,6 @@ from fabric.api import hide
 from fabric.api import put
 from fabric.api import run
 from fabric.api import settings as fabric_settings
-from fabric.api import warn_only
 from fabric.context_managers import shell_env
 from fauxfactory import gen_string
 from nailgun import entities
@@ -801,30 +801,6 @@ def check_ntpd():
         run("chkconfig ntpd on")
 
 
-def setup_satellite_repo():
-    """
-    Task which install foreman-maintain tool.
-    """
-    env.disable_known_hosts = True
-    # setting up foreman-maintain repo
-    setup_foreman_maintain_repo()
-    if settings.upgrade.distribution != 'cdn':
-        for repo, repodata in CUSTOM_SAT_REPO.items():
-            if repo != 'maintenance':
-                repository_setup(**repodata)
-
-
-def setup_foreman_maintain_repo():
-    """
-    Task which setup repo for foreman-maintain.
-    """
-    # setting up foreman-maintain repo
-    if settings.upgrade.distribution == 'cdn':
-        enable_repos(RH_CONTENT['maintenance']['label'])
-    else:
-        repository_setup(**CUSTOM_SAT_REPO['maintenance'])
-
-
 def hammer_config():
     """
     Use to update the hammer config file on the satellite
@@ -840,28 +816,96 @@ def hammer_config():
     hammer_file.close()
 
 
-def upgrade_using_foreman_maintain(satellite=True):
+def setup_satellite_repo():
+    """
+    Task which setups internal satellite repo.
+    """
+    if settings.upgrade.distribution != 'cdn':
+        repository_setup(**CUSTOM_SAT_REPO['satellite'])
+
+
+def setup_maintenance_repo():
+    """
+    Task which setups maintenance repo.
+    """
+    if settings.upgrade.distribution == 'cdn':
+        enable_repos(RH_CONTENT['maintenance']['label'])
+    else:
+        repository_setup(**CUSTOM_SAT_REPO['maintenance'])
+
+
+def setup_capsule_repo(fetch_content_from_sat=True):
+    """
+    Task which setups capsule repo.
+    """
+    if settings.upgrade.distribution != 'cdn':
+        if fetch_content_from_sat:
+            product_label = CUSTOM_CONTENT['capsule']['prod']
+            repo_label = CUSTOM_CONTENT['capsule']['reposet']
+            enable_repos(f'Default_Organization_{product_label}_{repo_label}')
+        else:
+            repository_setup(**CUSTOM_SAT_REPO['capsule'])
+
+
+def setup_capsule_maintenance_repo(fetch_content_from_sat=True):
+    """
+    Task which setups maintenance repo on capsule.
+    """
+    if settings.upgrade.distribution == 'cdn':
+        enable_disable_repo(
+            enable_repos_name=RH_CONTENT['maintenance']['label'],
+            disable_repos_name=RH_CONTENT['capsule']['label'],
+        )
+    elif fetch_content_from_sat:
+        maintenance_product = CUSTOM_CONTENT['maintenance']['prod']
+        maintenance_repo = CUSTOM_CONTENT['maintenance']['reposet']
+        capsule_product = CUSTOM_CONTENT['capsule']['prod']
+        capsule_repo = CUSTOM_CONTENT['capsule']['reposet']
+        enable_disable_repo(
+            enable_repos_name=f'Default_Organization_{maintenance_product}_{maintenance_repo}',
+            disable_repos_name=f'Default_Organization_{capsule_product}_{capsule_repo}',
+        )
+    else:
+        repository_setup(**CUSTOM_SAT_REPO['maintenance'])
+
+
+def foreman_maintain_self_upgrade(zstream=False, fetch_content_from_sat=False):
+    """
+    Install the latest fm rubygem-foreman_maintain to get the latest y-stream upgrade path.
+    """
+    if zstream:
+        run('foreman-maintain upgrade list-versions', warn_only=True)
+    else:
+        command = 'foreman-maintain self-upgrade'
+        if settings.upgrade.distribution != 'cdn':
+            if fetch_content_from_sat:
+                product_label = CUSTOM_CONTENT['maintenance']['prod']
+                repo_label = CUSTOM_CONTENT['maintenance']['reposet']
+                maintenance_repo = f'Default_Organization_{product_label}_{repo_label}'
+            else:
+                maintenance_repo = CUSTOM_SAT_REPO['maintenance']['repository']
+            command += f' --maintenance-repo-label {maintenance_repo}'
+        run(command)
+
+    run('rpm -qa rubygem-foreman_maintain')
+
+
+def foreman_maintain_upgrade(satellite=True):
     """Task which upgrades the product using foreman-maintain tool.
 
     :param bool satellite: True (=satellite upgrade) or False (=capsule upgrade)
     """
     env.disable_known_hosts = True
 
-    def satellite_upgrade_check(zstream=False):
-        with warn_only():
-            version_suffix = '.z' if zstream else ''
-            run(f'foreman-maintain upgrade check --plaintext '
-                f'--whitelist="repositories-validate" '
-                f'--target-version {settings.upgrade.to_version}{version_suffix} -y')
+    def upgrade_check(zstream=False):
+        version_suffix = '.z' if zstream else ''
+        run(
+            f'foreman-maintain upgrade check --plaintext --whitelist="repositories-validate" '
+            f'--target-version {settings.upgrade.to_version}{version_suffix} -y',
+            warn_only=True
+        )
 
-    def capsule_upgrade_check(zstream=False):
-        with warn_only():
-            version_suffix = '.z' if zstream else ''
-            run(f'foreman-maintain upgrade check --plaintext '
-                f'--whitelist="repositories-validate" '
-                f'--target-version {settings.upgrade.to_version}{version_suffix} -y')
-
-    def satellite_upgrade(zstream=False):
+    def upgrade_run(zstream=False):
         """ This inner function is used to perform Y & Z satellite stream upgrade"""
         version_suffix = '.z' if zstream else ''
         whitelist_param = ''
@@ -876,46 +920,24 @@ def upgrade_using_foreman_maintain(satellite=True):
             f'foreman-maintain upgrade run --plaintext {whitelist_param} '
             f'--target-version {settings.upgrade.to_version}{version_suffix} -y'
         )
-        # use Beta until becomes GA
-        if settings.upgrade.to_version == '6.12':
-            with shell_env(FOREMAN_MAINTAIN_USE_BETA='1'):
-                run(command)
-        else:
+        with (
+            shell_env(FOREMAN_MAINTAIN_USE_BETA='1')
+            if satellite and settings.upgrade.use_beta
+            else nullcontext()
+        ):
             run(command)
 
-    def capsule_upgrade(zstream=False):
-        """ This inner function is used to perform Y & Z stream Capsule upgrade"""
-        version_suffix = '.z' if zstream else ''
-        # z capsule stream upgrade, If we do not whitelist the repos setup then cdn
-        # repos of target version gets enabled.
-        whitelist_param = ''
-        if settings.upgrade.whitelist_param:
-            whitelist_param = f'--whitelist={settings.upgrade.whitelist_param}'
-        if settings.upgrade.distribution != 'cdn':
-            whitelist_param = (
-                f'--whitelist=repositories-validate,repositories-setup,'
-                f'{settings.upgrade.whitelist_param}'
-            )
-        run(f'foreman-maintain upgrade run --plaintext {whitelist_param} '
-            f'--target-version {settings.upgrade.to_version}{version_suffix} -y')
+    run('foreman-maintain upgrade list-versions', warn_only=True)
 
-    with warn_only():
-        run('foreman-maintain upgrade list-versions')  # we usually trigger self-upgrade here
     zstream = settings.upgrade.from_version == settings.upgrade.to_version
-    if satellite:
-        satellite_upgrade_check(zstream)
-        preup_time = datetime.now().replace(microsecond=0)
-        satellite_upgrade(zstream)
-    else:
-        capsule_upgrade_check(zstream)
-        preup_time = datetime.now().replace(microsecond=0)
-        capsule_upgrade(zstream)
-    postup_time = datetime.now().replace(microsecond=0)
+    upgrade_check(zstream)
 
-    if satellite:
-        logger.highlight(f'Time taken for satellite upgrade - {str(postup_time - preup_time)}')
-    else:
-        logger.highlight(f'Time taken for capsule upgrade - {str(postup_time - preup_time)}')
+    preup_time = datetime.now().replace(microsecond=0)
+    upgrade_run(zstream)
+    postup_time = datetime.now().replace(microsecond=0)
+    delta_time = postup_time - preup_time
+
+    logger.highlight(f"{'Satellite' if satellite else 'Capsule'} upgrade has taken - {delta_time}")
 
 
 def get_osp_hostname(ipaddr):
@@ -1055,9 +1077,13 @@ def enable_disable_repo(disable_repos_name=None, enable_repos_name=None):
     repository which you are going to enable
     """
     if disable_repos_name:
-        [disable_repos(f'{repo}', silent=True) for repo in disable_repos_name]
+        disable_repos(
+            * disable_repos_name if isinstance(disable_repos_name, list) else [disable_repos_name]
+        )
     if enable_repos_name:
-        [enable_repos(f'{repo}') for repo in enable_repos_name]
+        enable_repos(
+            * enable_repos_name if isinstance(enable_repos_name, list) else [enable_repos_name]
+        )
 
 
 def upgrade_task(upgrade_type, cap_host=None):
@@ -1218,28 +1244,6 @@ def repos_sync_failure_remiediation(org, repo_object, timeout=3000):
             upgrade_validation(upgrade_type="satellite",
                                satellite_services_action="start")
             logger.warning(f'Retry:{attempt} Repos sync remediation failed due to {exp}')
-
-
-def foreman_maintain_package_update(zstream=False, fetch_content_from_sat=False):
-    """
-    Install the latest fm rubygem-foreman_maintain to get the latest y-stream upgrade path.
-    """
-    if zstream:
-        with warn_only():
-            run('foreman-maintain upgrade list-versions')
-    else:
-        if settings.upgrade.distribution == 'cdn':
-            run('foreman-maintain self-upgrade')
-        else:
-            product_label = CUSTOM_CONTENT['maintenance']['prod']
-            repo_label = CUSTOM_CONTENT['maintenance']['reposet']
-            maintenance_repo = (
-                f'Default_Organization_{product_label}_{repo_label}'
-                if fetch_content_from_sat
-                else CUSTOM_SAT_REPO['maintenance']['repository']
-            )
-            run(f'foreman-maintain self-upgrade --maintenance-repo-label {maintenance_repo}')
-    run('rpm -qa rubygem-foreman_maintain')
 
 
 def yum_repos_cleanup():

--- a/upgrade/runner.py
+++ b/upgrade/runner.py
@@ -18,7 +18,7 @@ from upgrade.helpers.tasks import post_upgrade_test_tasks
 from upgrade.helpers.tasks import pre_upgrade_system_checks
 from upgrade.helpers.tasks import satellite_restore
 from upgrade.helpers.tasks import satellite_restore_setup
-from upgrade.helpers.tasks import setup_foreman_maintain_repo
+from upgrade.helpers.tasks import setup_maintenance_repo
 from upgrade.helpers.tasks import subscribe
 from upgrade.helpers.tasks import unsubscribe
 from upgrade.helpers.tools import create_setup_dict
@@ -87,7 +87,7 @@ def product_setup_for_db_upgrade(satellite):
     settings.upgrade.satellite_hostname = satellite
     execute(unsubscribe, host=satellite)
     execute(subscribe, host=satellite)
-    execute(setup_foreman_maintain_repo, host=satellite)
+    execute(setup_maintenance_repo, host=satellite)
     execute(satellite_restore_setup, host=satellite)
     execute(satellite_restore, host=satellite)
 


### PR DESCRIPTION
We are required to enable internal repositories gradually to perform exact steps in the same order described by the documentation.

Next version maintenance repository has to be enabled first, then is performed self-upgrade and after that we can enable other internal  repositories.

Coverage for [BZ#2143451](https://bugzilla.redhat.com/show_bug.cgi?id=2143451)

Depends on satelliteqe-jenkins `!995`