### PR TITLE
Enable satellite repo if satellite-maintenance module is missing

### DIFF
--- a/upgrade/helpers/constants/constants.py
+++ b/upgrade/helpers/constants/constants.py
@@ -43,6 +43,12 @@ RH_CONTENT = {
         'repo': f'Red Hat Satellite Maintenance {target_version} for RHEL {os_ver} {arch} RPMs',
         'label': f'satellite-maintenance-{target_version}-for-rhel-{os_ver}-{arch}-rpms'
     },
+    'satellite': {
+        'prod': 'Red Hat Satellite',
+        'reposet': f'Red Hat Satellite {target_version} for RHEL {os_ver} {arch} (RPMs)',
+        'repo': f'Red Hat Satellite {target_version} for RHEL {os_ver} {arch} RPMs',
+        'label': f'satellite-{target_version}-for-rhel-{os_ver}-{arch}-rpms'
+    },
 }
 
 OS_REPOS = dict(filter(lambda i: i[0] in os_repo_tags, RH_CONTENT.items()))

--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -826,10 +826,18 @@ def setup_maintenance_repo():
     """
     Task which setups maintenance repo.
     """
+    def module_not_present():
+        return run('dnf -y module list satellite-maintenance', warn_only=True).failed
     if settings.upgrade.distribution == 'cdn':
         enable_repos(RH_CONTENT['maintenance']['label'])
+        # enable satellite repo if maintenace module not yet released
+        if module_not_present():
+            enable_repos(RH_CONTENT['satellite']['label'])
     else:
         repository_setup(**CUSTOM_SAT_REPO['maintenance'])
+        # enable satellite repo if maintenace module not yet released
+        if module_not_present():
+            repository_setup(**CUSTOM_SAT_REPO['satellite'])
 
 
 def setup_capsule_repo(fetch_content_from_sat=True):
@@ -849,11 +857,16 @@ def setup_capsule_maintenance_repo(fetch_content_from_sat=True):
     """
     Task which setups maintenance repo on capsule.
     """
+    def module_not_present():
+        return run('dnf -y module list satellite-maintenance', warn_only=True).failed
     if settings.upgrade.distribution == 'cdn':
         enable_disable_repo(
             enable_repos_name=RH_CONTENT['maintenance']['label'],
             disable_repos_name=RH_CONTENT['capsule']['label'],
         )
+        # enable capsule repo if maintenace module not yet released
+        if module_not_present():
+            enable_disable_repo(enable_repos_name=RH_CONTENT['capsule']['label'])
     elif fetch_content_from_sat:
         maintenance_product = CUSTOM_CONTENT['maintenance']['prod']
         maintenance_repo = CUSTOM_CONTENT['maintenance']['reposet']
@@ -863,8 +876,16 @@ def setup_capsule_maintenance_repo(fetch_content_from_sat=True):
             enable_repos_name=f'Default_Organization_{maintenance_product}_{maintenance_repo}',
             disable_repos_name=f'Default_Organization_{capsule_product}_{capsule_repo}',
         )
+        # enable capsule repo if maintenace module not yet released
+        if module_not_present():
+            enable_disable_repo(
+                enable_repos_name=f'Default_Organization_{capsule_product}_{capsule_repo}',
+            )
     else:
         repository_setup(**CUSTOM_SAT_REPO['maintenance'])
+        # enable capsule repo if maintenace module not yet released
+        if module_not_present():
+            repository_setup(**CUSTOM_SAT_REPO['capsule'])
 
 
 def foreman_maintain_self_upgrade(zstream=False, fetch_content_from_sat=False):


### PR DESCRIPTION
This PR handles a situation when maintenance module is not (yet?) in maintenace repo - then enable satellite repo as a workaround

Only required in `6.12.z` and `6.11.z` branches