### PR TITLE
During restore enable maintenance module only if available

### DIFF
--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -1301,7 +1301,9 @@ def satellite_restore_setup():
         run(f'cd /usr/share; git clone -q {settings.clone.satellite_clone_upstream_repos}')
     else:
         run('yum -d1 repolist')
-        run(f'yum -d1 module enable -y satellite-maintenance:el{os_ver}')
+        module_name = f'satellite-maintenance:el{os_ver}'
+        if run(f'yum -d1 module list -y {module_name}', warn_only=True).suceeded:
+            run(f'yum -d1 module enable -y {module_name}')
         run('yum -d1 install -y satellite-clone')
     run(
         f'echo "satellite_version: {settings.upgrade.from_version}">>{answer_file};'


### PR DESCRIPTION
This PR handles a situation during restore when maintenance module is not (yet?) in maintenace repo

Change is not needed in master only in older branches so technically no cherrypick for 6.13.z