### PR TITLE
Upload new manifest instead of manifest refresh

### DIFF
--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -28,6 +28,7 @@ from fabric.api import settings as fabric_settings
 from fabric.context_managers import shell_env
 from fauxfactory import gen_string
 from nailgun import entities
+from nailgun.entity_mixins import TaskFailedError
 from packaging.version import Version
 
 from upgrade.helpers import nailgun_conf
@@ -168,10 +169,19 @@ def sync_capsule_repos_to_satellite(capsules):
         logger.highlight("The AK name is not provided for Capsule upgrade. Aborting...")
         sys.exit(1)
     org = entities.Organization(nailgun_conf, id=1).read()
-    logger.info("Refreshing the attached manifest")
-    entities.Subscription(nailgun_conf, organization=org).refresh_manifest(
-        data={'organization_id': org.id}, timeout=5000
-    )
+    try:
+        entities.Subscription(nailgun_conf, organization=org).delete_manifest(
+            data={'organization_id': org.id},
+        )
+    except TaskFailedError as exp:
+        logger.info(f"Manifest deletion failed with {exp}")
+    finally:
+        manifest = requests.get(settings.fake_manifest.url.default, verify=False).content
+        logger.info("Uploading new manifest")
+        entities.Subscription(nailgun_conf, organization=org).upload(
+            data={'organization_id': org.id}, files={'content': manifest}
+        )
+
     ak = entities.ActivationKey(nailgun_conf, organization=org).search(
         query={'search': f'name={capsule_ak}'})[0]
     add_satellite_subscriptions_in_capsule_ak(ak, org)


### PR DESCRIPTION
### Problem
After some time period the manifest uploaded in upgrade template expires and refreshing expired manifest is not possible.
```
INFO:upgrade_logging:Refreshing the attached manifest
WARNING:nailgun.client:Received HTTP 400 response: ****"displayMessage":"This Organization's subscription manifest has expired. Please import a new manifest.","errors":["This Organization's subscription manifest has expired. Please import a new manifest."]}
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.11/site-packages/fabric/main.py", line 758, in main
    execute(
  File "/opt/app-root/lib64/python3.11/site-packages/fabric/tasks.py", line 427, in execute
    results['<local-only>'] = task.run(*args, **new_kwargs)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/fabric/tasks.py", line 174, in run
    return self.wrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/src/satellite6-upgrade/upgrade/runner.py", line 59, in product_setup_for_upgrade_on_brokers_machine
    satellite_capsule_setup(
  File "/opt/app-root/src/satellite6-upgrade/upgrade/capsule.py", line 63, in satellite_capsule_setup
    execute(sync_capsule_repos_to_satellite, capsule_hosts, host=satellite_host)
  File "/opt/app-root/lib64/python3.11/site-packages/fabric/tasks.py", line 385, in execute
    results[host] = _execute(
                    ^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/fabric/tasks.py", line 277, in _execute
    return task.run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/fabric/tasks.py", line 174, in run
    return self.wrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/src/satellite6-upgrade/upgrade/helpers/tasks.py", line 172, in sync_capsule_repos_to_satellite
    entities.Subscription(nailgun_conf, organization=org).refresh_manifest(
  File "/opt/app-root/lib64/python3.11/site-packages/nailgun/entities.py", line 7723, in refresh_manifest
    return _handle_response(
           ^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/nailgun/entities.py", line 117, in _handle_response
    response.raise_for_status()
  File "/opt/app-root/lib64/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://satellite.example.com/katello/api/organizations/1/subscriptions/refresh_manifest
```

### Solution
Delete old manifest and upload new manifest instead of manifest refresh (which invalidates manifest for all other Satellites that are using it)
