### PR TITLE
Remove Satellite Tools

### DIFF
--- a/upgrade/capsule.py
+++ b/upgrade/capsule.py
@@ -53,7 +53,7 @@ def satellite_capsule_setup(satellite_host, capsule_hosts, os_version,
     if upgradable_capsule:
         if settings.upgrade.distribution == "cdn":
             settings.repos.capsule_repo = None
-            settings.repos.sattools_repo[settings.upgrade.os] = None
+            settings.repos.satclient_repo[settings.upgrade.os] = None
             settings.repos.satmaintenance_repo = None
         new_ak_status = execute(create_capsule_ak, host=satellite_host)
         execute(update_capsules_to_satellite, capsule_hosts, host=satellite_host)

--- a/upgrade/helpers/constants/constants.py
+++ b/upgrade/helpers/constants/constants.py
@@ -52,14 +52,6 @@ CUSTOM_CONTENT = {
         'prod': 'capsule_latest',
         'reposet': 'capsule_latest_repo',
     },
-    'capsule_tools': {
-        'prod': 'capsuletools_product',
-        'reposet': 'capsuletools_repo',
-    },
-    'tools': {
-        'prod': 'tools_latest_{client_os}',
-        'reposet': 'tools_latest_repo_{client_os}',
-    },
     'capsule_client': {
         'prod': 'capsuleclient_product',
         'reposet': 'capsuleclient_repo',


### PR DESCRIPTION
Tools repo was obsoleted by Client repo long ago. 
Most importantly we have separated branches for each version.
Lets remove it from branches where Tools repo is not valid.