### PR TITLE
Remove katello-agent prior to 6.15 upgrade

### DIFF
--- a/upgrade/helpers/tasks.py
+++ b/upgrade/helpers/tasks.py
@@ -940,6 +940,10 @@ def foreman_maintain_upgrade(satellite=True):
     zstream = settings.upgrade.from_version == settings.upgrade.to_version
     upgrade_check(zstream)
 
+    # Before upgrading to 6.15 users are requested to disable katello-agent
+    if not zstream and settings.upgrade.to_version == '6.15':
+        run('satellite-installer --foreman-proxy-content-enable-katello-agent false')
+
     preup_time = datetime.now().replace(microsecond=0)
     upgrade_run(zstream)
     postup_time = datetime.now().replace(microsecond=0)


### PR DESCRIPTION
Before upgrading to 6.15 users are requested to disable katello-agent
```
--------------------------------------------------------------------------------
Check whether the katello-agent feature is enabled before upgrading:  [FAIL]
The katello-agent feature is enabled on this system. As of Satellite 6.15, katello-agent is removed and will no longer function. Before proceeding with the upgrade, you should ensure that you have deployed and configured an alternative tool for remote package management and patching for content hosts, such as Remote Execution (REX) with pull-based transport. See the Managing Hosts guide in the Satellite documentation for more info. Disable katello-agent with the command `satellite-installer --foreman-proxy-content-enable-katello-agent false` before proceeding with the upgrade. Alternatively, you may skip this check and proceed by running satellite-maintain again with the `--whitelist` option, which will automatically uninstall katello-agent.
--------------------------------------------------------------------------------
```